### PR TITLE
Fix radio button selection for tax number and tax residency

### DIFF
--- a/btr-web/btr-main-app/components/individual-person/tax-info/TaxNumber.vue
+++ b/btr-web/btr-main-app/components/individual-person/tax-info/TaxNumber.vue
@@ -27,7 +27,9 @@
         :value="NO_TAX_NUMBER"
         @change="handleRadioButtonChange(NO_TAX_NUMBER)"
       />
-      <label class="ml-5"> {{ $t('labels.noTaxNumberLabel') }} </label>
+      <label for="noTaxNumberRadioButton" class="ml-5">
+        {{ $t('labels.noTaxNumberLabel') }}
+      </label>
     </div>
   </div>
 </template>

--- a/btr-web/btr-main-app/components/individual-person/tax-info/TaxResidency.vue
+++ b/btr-web/btr-main-app/components/individual-person/tax-info/TaxResidency.vue
@@ -2,12 +2,14 @@
   <UFormGroup :label="label" name="taxResidency" class="flex flex-col py-5">
     <div v-for="(option, index) in options" :key="index" class="flex items-center mb-2 py-1">
       <URadio
-        :id="`${id}-${option.value}`"
+        :id="`radio-${option.value}`"
         v-model="selectedValue"
         name="taxResidency"
         :value="option.value"
       />
-      <label class="ml-5"> {{ option.label }} </label>
+      <label :for="`radio-${option.value}`" class="ml-5">
+        {{ option.label }}
+      </label>
     </div>
   </UFormGroup>
 </template>


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/

*Description of changes:*
Fix the radio buttons for the Tax Number and Tax Residency component

Now we can select a radio button by clicking either the button or its label. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
