### PR TITLE
In-concert Control of Shares and Votes

### DIFF
--- a/btr-web/btr-common-components/app.config.ts
+++ b/btr-web/btr-common-components/app.config.ts
@@ -50,9 +50,10 @@ export default defineAppConfig({
       border: 'border-gray-500'
     },
     checkbox: {
-      wrapper: 'flex items-center',
+      wrapper: 'flex items-start',
+      base: 'mt-1 mr-2',
       border: 'border-gray-500',
-      label: 'text-base text-gray-900 ml-2'
+      label: 'text-base text-gray-900'
     },
     tooltip: {
       background: 'bg-gray-700',

--- a/btr-web/btr-main-app/app.vue
+++ b/btr-web/btr-main-app/app.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="bg-gray-100">
     <NuxtLayout>
-      <NuxtPage class="my-10 text-gray-900" />
+      <NuxtPage class="my-10 text-gray-900 text-left" />
     </NuxtLayout>
   </div>
 </template>

--- a/btr-web/btr-main-app/components/individual-person/AddNew.vue
+++ b/btr-web/btr-main-app/components/individual-person/AddNew.vue
@@ -65,7 +65,7 @@
         :schema="ownershipSchema"
         :state="significantIndividual"
       >
-        <div class="flex-col py-5">
+        <div class="flex-col pt-5">
           <p class="font-bold py-3">
             {{ $t('labels.sharesAndVotes') }}
           </p>
@@ -88,29 +88,18 @@
           />
         </div>
       </UForm>
-      <p class="text-justify pb-5">
-        <span class="font-bold">{{ $t('texts.note') }}</span>
-        {{ $t('texts.sharesAndVotes.note1') }}
-      </p>
-      <div>
-        <p class="text-justify">
-          {{ $t('texts.sharesAndVotes.typeOfControl') }}
-        </p>
+
+      <div class="flex-col py-5">
         <IndividualPersonControlTypeOfControl
           id="typeOfControl"
           v-model="significantIndividual.controlType.sharesVotes"
           name="typeOfControl"
           data-cy="testTypeOfControl"
         />
-        <p class="text-justify pb-5">
-          <span class="font-bold">{{ $t('texts.note') }}</span>
-          {{ $t('texts.sharesAndVotes.note2') }}
-        </p>
-        <p class="text-justify pb-5">
-          <span class="font-bold">{{ $t('texts.note') }}</span>
-          {{ $t('texts.sharesAndVotes.note3') }}
-        </p>
+
+        {{  significantIndividual.controlType.sharesVotes }}
       </div>
+
       <div class="flex-col py-5">
         <p class="font-bold py-3">
           {{ $t('labels.controlOfDirectors') }}
@@ -130,6 +119,9 @@
           <span class="font-bold">{{ $t('texts.note') }}</span>
           {{ $t('texts.controlOfDirectors.note') }}
         </p>
+
+        {{  significantIndividual.controlType.directors }}
+
       </div>
       <div class="flex-col py-5">
         <p class="font-bold py-3">
@@ -249,7 +241,7 @@ const defaultSI = {
       directControl: false,
       indirectControl: false,
       significantInfluence: false,
-      noControl: false
+      inConcertControl: false
     },
     other: ''
   },

--- a/btr-web/btr-main-app/components/individual-person/AddNew.vue
+++ b/btr-web/btr-main-app/components/individual-person/AddNew.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="significantIndividual" data-test="addIndividualPerson" class="flex-col w-full">
     <div>
-      <p class="text-justify">
+      <p>
         {{ $t('texts.addIndividualPerson') }}
       </p>
     </div>
@@ -53,11 +53,11 @@
         <p class="font-bold py-3">
           {{ $t('labels.beneficialOwnershipAssessment') }}
         </p>
-        <p class="text-justify">
+        <p>
           {{ $t('texts.beneficialOwnershipAssessmentText1') }}
         </p>
         <br>
-        <p class="text-justify">
+        <p>
           {{ $t('texts.beneficialOwnershipAssessmentText2') }}
         </p>
       </div>
@@ -69,7 +69,7 @@
           <p class="font-bold py-3">
             {{ $t('labels.sharesAndVotes') }}
           </p>
-          <p class="text-justify">
+          <p>
             {{ $t('texts.sharesAndVotes.controlPercentage') }}
           </p>
           <IndividualPersonControlPercentage
@@ -100,7 +100,7 @@
         <p class="font-bold py-3">
           {{ $t('labels.controlOfDirectors') }}
         </p>
-        <p class="text-justify">
+        <p>
           {{ $t('texts.controlOfDirectors.text.part1') }}
           <span class="font-bold">{{ $t('texts.controlOfDirectors.text.part2') }}</span>
           {{ $t('texts.controlOfDirectors.text.part3') }}
@@ -111,7 +111,7 @@
           name="controlOfDirectors"
           data-cy="testControlOfDirectors"
         />
-        <p class="text-justify">
+        <p>
           <span class="font-bold">{{ $t('texts.note') }}</span>
           {{ $t('texts.controlOfDirectors.note') }}
         </p>
@@ -137,7 +137,7 @@
         <p class="font-bold py-3">
           {{ $t('labels.citizenshipPermanentResidency') }}
         </p>
-        <p class="text-justify">
+        <p>
           {{ $t('texts.citizenshipPermanentResidency') }}
         </p>
         <BcrosInputsCountriesOfCitizenship
@@ -154,7 +154,7 @@
           <p class="font-bold py-3">
             {{ $t('labels.taxNumber') }}
           </p>
-          <p class="text-justify">
+          <p>
             {{ $t('texts.taxNumber') }}
           </p>
           <IndividualPersonTaxInfoTaxNumber
@@ -169,7 +169,7 @@
         <p class="font-bold py-3">
           {{ $t('labels.taxResidency') }}
         </p>
-        <p class="text-justify">
+        <p>
           {{ $t('texts.taxResidency') }}
         </p>
         <IndividualPersonTaxInfoTaxResidency

--- a/btr-web/btr-main-app/components/individual-person/AddNew.vue
+++ b/btr-web/btr-main-app/components/individual-person/AddNew.vue
@@ -88,7 +88,6 @@
           />
         </div>
       </UForm>
-
       <div class="flex-col py-5">
         <IndividualPersonControlTypeOfControl
           id="typeOfControl"
@@ -96,10 +95,7 @@
           name="typeOfControl"
           data-cy="testTypeOfControl"
         />
-
-        {{  significantIndividual.controlType.sharesVotes }}
       </div>
-
       <div class="flex-col py-5">
         <p class="font-bold py-3">
           {{ $t('labels.controlOfDirectors') }}
@@ -119,9 +115,6 @@
           <span class="font-bold">{{ $t('texts.note') }}</span>
           {{ $t('texts.controlOfDirectors.note') }}
         </p>
-
-        {{  significantIndividual.controlType.directors }}
-
       </div>
       <div class="flex-col py-5">
         <p class="font-bold py-3">

--- a/btr-web/btr-main-app/components/individual-person/SummaryTable.vue
+++ b/btr-web/btr-main-app/components/individual-person/SummaryTable.vue
@@ -53,7 +53,7 @@
               {{ $t('labels.directors') }}
             </h4>
             <p>{{ getDirectorsControlText(row.controlType.directors) }}</p>
-            <p v-if="row.controlType.directors.noControl">
+            <p v-if="row.controlType.directors.inConcertControl">
               {{ $t('texts.controlOfDirectors.summary.inConcert') }}
             </p>
           </div>

--- a/btr-web/btr-main-app/components/individual-person/control/ControlOfDirectors.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/ControlOfDirectors.vue
@@ -9,12 +9,12 @@
       />
     </div>
     <UCheckbox
-      v-model="controlOfDirectors.noControl"
-      name="noControl"
+      v-model="controlOfDirectors.inConcertControl"
+      name="inConcertControl"
       class="py-2 mt-5"
     >
       <template #label>
-        {{ $t('texts.controlOfDirectors.noControl.text') }}
+        {{ $t('texts.controlOfDirectors.inConcertControl.text') }}
         <UTooltip
           class="underline underline-offset-4 decoration-dotted"
           :popper="{
@@ -25,10 +25,10 @@
         >
           <template #text>
             <span class="whitespace-normal place-content: center">
-              {{ $t('texts.controlOfDirectors.noControl.tooltipContent') }}
+              {{ $t('texts.controlOfDirectors.inConcertControl.tooltipContent') }}
             </span>
           </template>
-          {{ $t('texts.controlOfDirectors.noControl.tooltip') }}
+          {{ $t('texts.controlOfDirectors.inConcertControl.tooltip') }}
         </UTooltip>
       </template>
     </UCheckbox>
@@ -45,7 +45,7 @@ const prop = defineProps({
       directControl: false,
       indirectControl: false,
       significantInfluence: false,
-      noControl: false
+      inConcertControl: false
     })
   }
 })

--- a/btr-web/btr-main-app/components/individual-person/control/TypeOfControl.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/TypeOfControl.vue
@@ -1,59 +1,56 @@
 <template>
-  <UCheckbox
-    v-model="typeOfControl['inConcertControl']"
-    name="inConcertControl"
-    class="pb-5"
-  >
-    <template #label>
-      {{ $t('texts.sharesAndVotes.inConcertControl.part1') }}
-      <UTooltip
-        class="underline underline-offset-4 decoration-dotted"
-        :popper="{
-          placement: 'top',
-          arrow: true
-        }"
-        data-cy="testControlOfDirectorsTooltip"
-      >
-        <template #text>
-          <span class="whitespace-normal place-content: center">
-            {{ $t('texts.sharesAndVotes.inConcertControl.tooltipContent') }}
-          </span>
-        </template>
-        {{ $t('texts.sharesAndVotes.inConcertControl.tooltip') }}
-      </UTooltip>
-      {{ $t('texts.sharesAndVotes.inConcertControl.part2') }}
-    </template>
-  </UCheckbox>
-
-  <p class="text-justify pb-5">
-    <span class="font-bold">{{ $t('texts.note') }}</span>
-    {{ $t('texts.sharesAndVotes.note1') }}
-  </p>
-
-  <p class="text-justify">
-    {{ $t('texts.sharesAndVotes.typeOfControl') }}
-  </p>
-
-
-  <div :id="id" class="flex flex-col py-5">
-    <div v-for="type in types" :key="type.value">
-      <UCheckbox
-        v-model="typeOfControl[type.value]"
-        :name="type.value"
-        :label="type.label"
-        class="py-2"
-      />
+  <div>
+    <UCheckbox
+      v-model="typeOfControl[IN_CONCERT_CONTROL]"
+      :name="IN_CONCERT_CONTROL"
+      class="pb-5"
+    >
+      <template #label>
+        {{ $t('texts.sharesAndVotes.inConcertControl.part1') }}
+        <UTooltip
+          class="underline underline-offset-4 decoration-dotted"
+          :popper="{
+            placement: 'top',
+            arrow: true
+          }"
+          data-cy="testInConcertControlTooltip"
+        >
+          <template #text>
+            <span class="whitespace-normal place-content: center">
+              {{ $t('texts.sharesAndVotes.inConcertControl.tooltipContent') }}
+            </span>
+          </template>
+          {{ $t('texts.sharesAndVotes.inConcertControl.tooltip') }}
+        </UTooltip>
+        {{ $t('texts.sharesAndVotes.inConcertControl.part2') }}
+      </template>
+    </UCheckbox>
+    <p class="text-justify pb-5">
+      <span class="font-bold">{{ $t('texts.note') }}</span>
+      {{ $t('texts.sharesAndVotes.note1') }}
+    </p>
+    <p class="text-justify">
+      {{ $t('texts.sharesAndVotes.typeOfControl') }}
+    </p>
+    <div :id="id" class="flex flex-col py-5">
+      <div v-for="type in types" :key="type.value">
+        <UCheckbox
+          v-model="typeOfControl[type.value]"
+          :name="type.value"
+          :label="type.label"
+          class="py-2"
+        />
+      </div>
     </div>
+    <p class="text-justify pb-5">
+      <span class="font-bold">{{ $t('texts.note') }}</span>
+      {{ $t('texts.sharesAndVotes.note2') }}
+    </p>
+    <p class="text-justify pb-5">
+      <span class="font-bold">{{ $t('texts.note') }}</span>
+      {{ $t('texts.sharesAndVotes.note3') }}
+    </p>
   </div>
-
-  <p class="text-justify pb-5">
-    <span class="font-bold">{{ $t('texts.note') }}</span>
-    {{ $t('texts.sharesAndVotes.note2') }}
-  </p>
-  <p class="text-justify pb-5">
-    <span class="font-bold">{{ $t('texts.note') }}</span>
-    {{ $t('texts.sharesAndVotes.note3') }}
-  </p>
 </template>
 
 <script setup lang="ts">
@@ -70,6 +67,7 @@ const prop = defineProps({
   }
 })
 
+const IN_CONCERT_CONTROL = 'inConcertControl'
 const { t } = useI18n()
 const types = [
   { value: 'registeredOwner', label: t('texts.sharesAndVotes.registeredOwner') },

--- a/btr-web/btr-main-app/components/individual-person/control/TypeOfControl.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/TypeOfControl.vue
@@ -25,11 +25,11 @@
         {{ $t('texts.sharesAndVotes.inConcertControl.part2') }}
       </template>
     </UCheckbox>
-    <p class="text-justify pb-5">
+    <p class="pb-5">
       <span class="font-bold">{{ $t('texts.note') }}</span>
       {{ $t('texts.sharesAndVotes.note1') }}
     </p>
-    <p class="text-justify">
+    <p>
       {{ $t('texts.sharesAndVotes.typeOfControl') }}
     </p>
     <div :id="id" class="flex flex-col py-5">
@@ -42,11 +42,11 @@
         />
       </div>
     </div>
-    <p class="text-justify pb-5">
+    <p class="pb-5">
       <span class="font-bold">{{ $t('texts.note') }}</span>
       {{ $t('texts.sharesAndVotes.note2') }}
     </p>
-    <p class="text-justify pb-5">
+    <p>
       <span class="font-bold">{{ $t('texts.note') }}</span>
       {{ $t('texts.sharesAndVotes.note3') }}
     </p>

--- a/btr-web/btr-main-app/components/individual-person/control/TypeOfControl.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/TypeOfControl.vue
@@ -1,4 +1,40 @@
 <template>
+  <UCheckbox
+    v-model="typeOfControl['inConcertControl']"
+    name="inConcertControl"
+    class="pb-5"
+  >
+    <template #label>
+      {{ $t('texts.sharesAndVotes.inConcertControl.part1') }}
+      <UTooltip
+        class="underline underline-offset-4 decoration-dotted"
+        :popper="{
+          placement: 'top',
+          arrow: true
+        }"
+        data-cy="testControlOfDirectorsTooltip"
+      >
+        <template #text>
+          <span class="whitespace-normal place-content: center">
+            {{ $t('texts.sharesAndVotes.inConcertControl.tooltipContent') }}
+          </span>
+        </template>
+        {{ $t('texts.sharesAndVotes.inConcertControl.tooltip') }}
+      </UTooltip>
+      {{ $t('texts.sharesAndVotes.inConcertControl.part2') }}
+    </template>
+  </UCheckbox>
+
+  <p class="text-justify pb-5">
+    <span class="font-bold">{{ $t('texts.note') }}</span>
+    {{ $t('texts.sharesAndVotes.note1') }}
+  </p>
+
+  <p class="text-justify">
+    {{ $t('texts.sharesAndVotes.typeOfControl') }}
+  </p>
+
+
   <div :id="id" class="flex flex-col py-5">
     <div v-for="type in types" :key="type.value">
       <UCheckbox
@@ -9,6 +45,15 @@
       />
     </div>
   </div>
+
+  <p class="text-justify pb-5">
+    <span class="font-bold">{{ $t('texts.note') }}</span>
+    {{ $t('texts.sharesAndVotes.note2') }}
+  </p>
+  <p class="text-justify pb-5">
+    <span class="font-bold">{{ $t('texts.note') }}</span>
+    {{ $t('texts.sharesAndVotes.note3') }}
+  </p>
 </template>
 
 <script setup lang="ts">
@@ -19,16 +64,17 @@ const prop = defineProps({
     default: () => ({
       registeredOwner: false,
       beneficialOwner: false,
-      indirectControl: false
+      indirectControl: false,
+      inConcertControl: false
     })
   }
 })
 
 const { t } = useI18n()
 const types = [
-  { value: 'registeredOwner', label: t('labels.registeredOwner') },
-  { value: 'beneficialOwner', label: t('labels.beneficialOwner') },
-  { value: 'indirectControl', label: t('labels.indirectControl') }
+  { value: 'registeredOwner', label: t('texts.sharesAndVotes.registeredOwner') },
+  { value: 'beneficialOwner', label: t('texts.sharesAndVotes.beneficialOwner') },
+  { value: 'indirectControl', label: t('texts.sharesAndVotes.indirectControl') }
 ]
 
 const typeOfControl: Ref<ControlOfSharesI> = ref(prop.modelValue)

--- a/btr-web/btr-main-app/cypress/e2e/pages/add-individual/control-of-majority-of-directors.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/pages/add-individual/control-of-majority-of-directors.cy.ts
@@ -18,7 +18,7 @@ describe('pages -> Add individual', () => {
     checkboxes.get('[name="directControl"]').check().should('be.checked')
     checkboxes.get('[name="indirectControl"]').check().should('be.checked')
     checkboxes.get('[name="significantInfluence"]').check().should('be.checked')
-    checkboxes.get('[name="noControl"]').check().should('be.checked')
+    checkboxes.get('[name="inConcertControl"]').check().should('be.checked')
   })
 
   it('test the tooltip', () => {
@@ -27,6 +27,6 @@ describe('pages -> Add individual', () => {
     const checkboxes = cy.get('[data-cy="testControlOfDirectors"]').should('exist')
 
     checkboxes.get('[data-cy="testControlOfDirectorsTooltip"]').trigger('mouseover')
-    cy.contains(en.texts.controlOfDirectors.noControl.tooltipContent).should('exist')
+    cy.contains(en.texts.sharesAndVotes.inConcertControl.tooltipContent).should('exist')
   })
 })

--- a/btr-web/btr-main-app/cypress/e2e/pages/add-individual/control-of-shares-and-votes.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/pages/add-individual/control-of-shares-and-votes.cy.ts
@@ -15,9 +15,17 @@ describe('pages -> Add individual', () => {
 
     const checkboxes = cy.get('[data-cy="testTypeOfControl"]').should('exist')
 
+    checkboxes.get('[name="inConcertControl"]').check().should('be.checked')
     checkboxes.get('[name="registeredOwner"]').check().should('be.checked')
     checkboxes.get('[name="beneficialOwner"]').check().should('be.checked')
     checkboxes.get('[name="indirectControl"]').check().should('be.checked')
+  })
+
+  it('test the tooltip for in-concert control', () => {
+    cy.get('[data-cy="showAddIndividualPersonManually"]').trigger('click')
+
+    cy.get('[data-cy="testInConcertControlTooltip"]').trigger('mouseover')
+    cy.contains(en.texts.controlOfDirectors.inConcertControl.tooltipContent).should('exist')
   })
 
   it('test the error message for special characters', () => {

--- a/btr-web/btr-main-app/interfaces/control-of-directors-i.ts
+++ b/btr-web/btr-main-app/interfaces/control-of-directors-i.ts
@@ -2,5 +2,5 @@ export interface ControlOfDirectorsI {
     directControl: boolean
     indirectControl: boolean
     significantInfluence: boolean
-    noControl: boolean
+    inConcertControl: boolean
 }

--- a/btr-web/btr-main-app/lang/en.json
+++ b/btr-web/btr-main-app/lang/en.json
@@ -47,7 +47,7 @@
     "sharesAndVotes": {
       "controlPercentage": "Enter the percentage of shares issued for the business and/or shares entitled to votes at general meetings this individual owns or ultimately controls (or can exercise ultimate effective control over).",
       "inConcertControl": {
-        "part1": "All individual has shares or votes exercised in concert with ",
+        "part1": "This individual has shares or votes exercised in concert with ",
         "tooltip": "other individuals",
         "tooltipContent": "Other individuals includes groups of individuals acting in concert, spouses, and relatives who live in the same home.",
         "part2": " and the total combined shares or votes of the group equals 25% or more"
@@ -69,7 +69,6 @@
         "registeredindirect": "Registered owner and Indirect control of {sharePercent}% of shares, {votePercent}% of votes",
         "inConcert": "25% or more of shares or votes exercised in concert"
       }
-      
     },
     "controlOfDirectors": {
       "text": {

--- a/btr-web/btr-main-app/lang/en.json
+++ b/btr-web/btr-main-app/lang/en.json
@@ -12,9 +12,6 @@
     "sharesAndVotes": "Control of Shares and Votes",
     "significanceDates": "Significance Dates",
     "lastKnownAddress": "Last Known Address",
-    "registeredOwner": "Registered owner",
-    "beneficialOwner": "Beneficial owner (e.g., through a trust)",
-    "indirectControl": "Indirect control (e.g., through another business)",
     "citizenshipPermanentResidency": "Citizenship / Permanent Residency",
     "taxNumber": "Canada Revenue Agency (CRA) Tax Number",
     "noTaxNumberLabel": "This person does not have a CRA Tax Number",
@@ -49,8 +46,17 @@
     "dateRange": "{start} to {end}",
     "sharesAndVotes": {
       "controlPercentage": "Enter the percentage of shares issued for the business and/or shares entitled to votes at general meetings this individual owns or ultimately controls (or can exercise ultimate effective control over).",
+      "inConcertControl": {
+        "part1": "All individual has shares or votes exercised in concert with ",
+        "tooltip": "other individuals",
+        "tooltipContent": "Other individuals includes groups of individuals acting in concert, spouses, and relatives who live in the same home.",
+        "part2": " and the total combined shares or votes of the group equals 25% or more"
+      },
       "note1": "All individuals with joint control of 25% or more of the issued shares must be listed as significant individuals.",
       "typeOfControl": "If this person controls shares or shares entitled to votes, indicate the type(s) of control of the shares and/or votes this person has:",
+      "registeredOwner": "Registered owner",
+      "beneficialOwner": "Beneficial owner (e.g., through a trust)",
+      "indirectControl": "Indirect control (e.g., through another business)",
       "note2": "If shares in this business are held in trust, you must list the Trustees as the Registered owner, and you must also list the beneficiaries of the trust as the Beneficial owners of the shares.",
       "note3": "Beneficiaries do not have to be listed in the transparency register if their beneficial interest is conditional on the death of another individual.",
       "summary": {
@@ -63,6 +69,7 @@
         "registeredindirect": "Registered owner and Indirect control of {sharePercent}% of shares, {votePercent}% of votes",
         "inConcert": "25% or more of shares or votes exercised in concert"
       }
+      
     },
     "controlOfDirectors": {
       "text": {
@@ -73,7 +80,7 @@
       "directControl": "Direct control",
       "indirectControl": "Indirect control (through another business)",
       "significantInfluence": "Significant influence control",
-      "noControl": {
+      "inConcertControl": {
         "text": "This individual has control of the majority of directors through rights and/or exercised in concert with",
         "tooltip": "other individuals",
         "tooltipContent": "Other individuals includes groups of individuals acting in concert, spouses, and relatives who live in the same home."

--- a/btr-web/btr-main-app/tests/components/individual-person/SummaryTable.spec.ts
+++ b/btr-web/btr-main-app/tests/components/individual-person/SummaryTable.spec.ts
@@ -81,7 +81,7 @@ describe('AddIndividualPersonSummaryTable tests', () => {
     si.controlType.directors.directControl = false
     si.controlType.directors.indirectControl = false
     si.controlType.directors.significantInfluence = false
-    si.controlType.directors.noControl = false
+    si.controlType.directors.inConcertControl = false
     si.controlType.other = ''
     await wrapper.setProps({ individuals: [si] })
     let controls = wrapper.find('[data-cy=summary-table-controls]')
@@ -99,7 +99,7 @@ describe('AddIndividualPersonSummaryTable tests', () => {
     si.controlType.directors.directControl = true
     si.controlType.directors.indirectControl = true
     si.controlType.directors.significantInfluence = true
-    si.controlType.directors.noControl = true
+    si.controlType.directors.inConcertControl = true
     si.controlType.other = ''
     await wrapper.setProps({ individuals: [si] })
     controls = wrapper.find('[data-cy=summary-table-controls]')
@@ -117,7 +117,7 @@ describe('AddIndividualPersonSummaryTable tests', () => {
     si.controlType.directors.directControl = false
     si.controlType.directors.indirectControl = false
     si.controlType.directors.significantInfluence = false
-    si.controlType.directors.noControl = false
+    si.controlType.directors.inConcertControl = false
     si.controlType.other = 'My lawyer said so'
     await wrapper.setProps({ individuals: [si] })
     controls = wrapper.find('[data-cy=summary-table-controls]')
@@ -133,7 +133,7 @@ describe('AddIndividualPersonSummaryTable tests', () => {
     si.controlType.directors.directControl = true
     si.controlType.directors.indirectControl = true
     si.controlType.directors.significantInfluence = false
-    si.controlType.directors.noControl = false
+    si.controlType.directors.inConcertControl = false
     si.controlType.other = 'My lawyer said so'
     await wrapper.setProps({ individuals: [si] })
     controls = wrapper.find('[data-cy=summary-table-controls]')

--- a/btr-web/btr-main-app/tests/utils/mockedData.ts
+++ b/btr-web/btr-main-app/tests/utils/mockedData.ts
@@ -34,7 +34,7 @@ export const testSI: SignificantIndividualI = {
       directControl: true,
       indirectControl: true,
       significantInfluence: false,
-      noControl: false
+      inConcertControl: false
     },
     other: ''
   },


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/18727

*Description of changes:*
- Add the checkbox for "share or votes exercised in concert with other individuals"
- Fix the naming in "Control of Directors". (the field that was labeled as "noControl" should actually be "inConcertControl") 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
