### PR TITLE
API: handle multiple SIs in one submission

### DIFF
--- a/btr-api/src/btr_api/__init__.py
+++ b/btr-api/src/btr_api/__init__.py
@@ -66,7 +66,7 @@ def create_app(environment: Config = Production, **kwargs) -> Flask:
         )
 
     db.init_app(app)
-     # td is testData instance passed in to support testing
+    # td is testData instance passed in to support testing
     td = kwargs.get('ld_test_data', None)
     Flags().init_app(app, td)    # queue.init_app(app)
     babel.init_app(app)

--- a/btr-api/src/btr_api/services/submission.py
+++ b/btr-api/src/btr_api/services/submission.py
@@ -42,26 +42,21 @@ class SubmissionService(object):
     def save_submission(submission_dict: dict) -> SubmissionModel:
         submission = SubmissionModel()
         submission.payload = submission_dict
-        
-        print("saving submission\n")
         submission.save()
 
         for significant_individual in submission_dict['significantIndividuals']:
-            print("saving a person")
             person = None
             if significant_individual.get('profile').get('uuid'):
-                print("person already exists with uuid", significant_individual['profile']['uuid'])
                 person = PersonModel.find_by_uuid(significant_individual['profile']['uuid'])
             else:
-                print("creating a new person")
                 person = PersonService.save_person_from_submission(submission_dict=submission_dict)
-        
+
             person_id = person.id if person else None
 
-            print("saving ownership details\n")
-            OwnershipDetailsService.save_ownership_details_from_submission(submission_dict=submission_dict,
-                                                                           submission_id=submission.id,
-                                                                           person_id=person_id)
+            OwnershipDetailsService.save_ownership_details_from_submission(
+                submission_dict=submission_dict,
+                submission_id=submission.id,
+                person_id=person_id
+            )
 
-        print(submission)
         return submission

--- a/btr-api/src/btr_api/services/submission.py
+++ b/btr-api/src/btr_api/services/submission.py
@@ -42,17 +42,26 @@ class SubmissionService(object):
     def save_submission(submission_dict: dict) -> SubmissionModel:
         submission = SubmissionModel()
         submission.payload = submission_dict
+        
+        print("saving submission\n")
         submission.save()
 
-        if 'person' in submission_dict and submission_dict['person'].get('uuid'):
-            person_uuid = submission_dict['person'].get('uuid')
-            person = PersonModel.find_by_uuid(person_uuid)
-        else:
-            person = PersonService.save_person_from_submission(submission_dict=submission_dict)
+        for significant_individual in submission_dict['significantIndividuals']:
+            print("saving a person")
+            person = None
+            if significant_individual.get('profile').get('uuid'):
+                print("person already exists with uuid", significant_individual['profile']['uuid'])
+                person = PersonModel.find_by_uuid(significant_individual['profile']['uuid'])
+            else:
+                print("creating a new person")
+                person = PersonService.save_person_from_submission(submission_dict=submission_dict)
+        
+            person_id = person.id if person else None
 
-        person_id = person.id if person else None
-        OwnershipDetailsService.save_ownership_details_from_submission(submission_dict=submission_dict,
-                                                                       submission_id=submission.id,
-                                                                       person_id=person_id)
+            print("saving ownership details\n")
+            OwnershipDetailsService.save_ownership_details_from_submission(submission_dict=submission_dict,
+                                                                           submission_id=submission.id,
+                                                                           person_id=person_id)
 
+        print(submission)
         return submission

--- a/btr-api/tests/unit/__init__.py
+++ b/btr-api/tests/unit/__init__.py
@@ -11,3 +11,131 @@ def nested_session(session):
         pass
     finally:
         pass
+
+INDIVIDUAL_1 = {
+    "controlType": {
+        "sharesVotes": {
+            "registeredOwner": True,
+            "beneficialOwner": False,
+            "indirectControl": True,
+            "inConcertControl": False
+        },
+        "directors": {
+            "directControl": True,
+            "indirectControl": False,
+            "significantInfluence": True,
+            "inConcertControl": True
+        },
+        "other": ""
+    },
+    "missingInfoReason": "",
+    "percentOfShares": "25%",
+    "percentOfVotes": "30%",
+    "profile": {
+        "address": {},
+        "competency": {
+            "decisionMaking": True,
+            "financialAffairs": False
+        },
+        "birthDate": "1980-03-01",
+        "citizenshipCA": "Canada",
+        "citizenshipsExCA": [],
+        "email": "example1@email.com",
+        "hasTaxNumber": True,
+        "isTaxResident": True,
+        "fullName": "John Doe",
+        "preferredName": "John",
+        "taxNumber": "123456789"
+    },
+    "startDate": "2023-01-01T00:00:00+00:00",
+    "endDate": "2024-01-01T00:00:00+00:00"
+}
+
+INDIVIDUAL_2 = {
+    "controlType": {
+        "sharesVotes": {
+            "registeredOwner": False,
+            "beneficialOwner": True,
+            "indirectControl": True,
+            "inConcertControl": False
+        },
+        "directors": {
+            "directControl": False,
+            "indirectControl": True,
+            "significantInfluence": False,
+            "inConcertControl": True
+        },
+        "other": ""
+    },
+    "missingInfoReason": "",
+    "percentOfShares": "12%",
+    "percentOfVotes": "11%",
+    "profile": {
+        "address": {},
+        "competency": {
+            "decisionMaking": True,
+            "financialAffairs": False
+        },
+        "birthDate": "1980-01-01",
+        "citizenshipCA": "Canada",
+        "citizenshipsExCA": [],
+        "email": "example2@email.com",
+        "hasTaxNumber": True,
+        "isTaxResident":True,
+        "fullName": "Jane Doe",
+        "preferredName": "",
+        "taxNumber": "123000111",
+        "uuid": "1112"
+    },
+    "startDate": "2023-01-01T00:00:00+00:00"
+}
+
+INDIVIDUAL_3 = {
+    "controlType": {
+        "sharesVotes": {
+            "registeredOwner": True,
+            "beneficialOwner": False,
+            "indirectControl": True,
+            "inConcertControl": False
+        },
+        "directors": {
+        "directControl": True,
+        "indirectControl": False,
+        "significantInfluence": True,
+        "inConcertControl": True
+        },
+        "other": "Other control details"
+    },
+    "missingInfoReason": "Not applicable",
+    "percentOfShares": "15%",
+    "percentOfVotes": "30%",
+    "profile": {
+        "address": {},
+        "competency": {
+            "decisionMaking": True,
+            "financialAffairs": False
+        },
+        "birthDate": "1990-01-01",
+        "citizenshipCA": "Canada",
+        "citizenshipsExCA": [],
+        "email": "example3@email.com",
+        "hasTaxNumber": True,
+        "isTaxResident": True,
+        "fullName": "test name",
+        "preferredName": "testing",
+        "taxNumber": "123456000"
+    },
+    "startDate": "2023-01-01T00:00:00+00:00"
+}
+
+TEST_SI_FILING = {
+    "businessIdentifier": "BC0871427",
+    "folioNumber": "12345",
+    "effectiveDate": "2023-12-11T10:00:00+00:00",
+    "significantIndividuals": [
+        INDIVIDUAL_1,
+        INDIVIDUAL_2,
+        INDIVIDUAL_3
+    ],
+    "certified": True
+}


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/18675

*Description of changes:*
update SubmissionService so it can handle multiple significant individuals in one filing submission.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
