### PR TITLE
Fix validation bugs for missingInfoReason and otherReason component

### DIFF
--- a/btr-web/btr-main-app/components/individual-person/AddNew.vue
+++ b/btr-web/btr-main-app/components/individual-person/AddNew.vue
@@ -383,7 +383,7 @@ function validateForm () {
     percentOfShares: significantIndividual.value.percentOfShares,
     percentOfVotes: significantIndividual.value.percentOfVotes,
     controlOfShares: significantIndividual.value.controlType.sharesVotes,
-    otherReason: significantIndividual.value.controlType.other,
+    otherReasons: significantIndividual.value.controlType.other,
     controlOfDirectors: significantIndividual.value.controlType.directors,
     birthDate: significantIndividual.value.profile.birthDate,
     country: {
@@ -596,7 +596,7 @@ const formSchema = z.object({
     indirectControl: z.boolean(),
     inConcertControl: z.boolean()
   }),
-  otherReason: z.string().optional(),
+  otherReasons: z.string().optional(),
   controlOfDirectors: z.object({
     directControl: z.boolean(),
     indirectControl: z.boolean(),
@@ -625,7 +625,7 @@ const formSchema = z.object({
 ).refine(
   validateControlOfDirectors, getMissingControlOfDirectorsError()
 ).refine(
-  validateOtherReason
+  validateOtherReasons
 ).refine(
   validateBirthDate, getMissingBirthDateError()
 ).refine(

--- a/btr-web/btr-main-app/components/individual-person/AddNew.vue
+++ b/btr-web/btr-main-app/components/individual-person/AddNew.vue
@@ -346,7 +346,9 @@ const fullNameInvalid = ref(false)
 const preferredNameInvalid = ref(false)
 const emailInvalid = ref(false)
 const taxNumebrInvalid = ref(false)
-const missingInfo = ref(false)
+const missingInfo = ref(
+  significantIndividual.value.missingInfoReason !== undefined && significantIndividual.value.missingInfoReason !== ''
+)
 
 const percentOfSharesInvalid = ref(false)
 const percentOfVotesInvalid = ref(false)
@@ -381,7 +383,7 @@ function validateForm () {
     percentOfShares: significantIndividual.value.percentOfShares,
     percentOfVotes: significantIndividual.value.percentOfVotes,
     controlOfShares: significantIndividual.value.controlType.sharesVotes,
-    otherReasons: significantIndividual.value.controlType.other,
+    otherReason: significantIndividual.value.controlType.other,
     controlOfDirectors: significantIndividual.value.controlType.directors,
     birthDate: significantIndividual.value.profile.birthDate,
     country: {
@@ -594,7 +596,7 @@ const formSchema = z.object({
     indirectControl: z.boolean(),
     inConcertControl: z.boolean()
   }),
-  otherReasons: z.string(),
+  otherReason: z.string().optional(),
   controlOfDirectors: z.object({
     directControl: z.boolean(),
     indirectControl: z.boolean(),

--- a/btr-web/btr-main-app/interfaces/form-input-i.ts
+++ b/btr-web/btr-main-app/interfaces/form-input-i.ts
@@ -5,7 +5,7 @@ export interface FormInputI {
   percentOfShares: string
   percentOfVotes: string
   controlOfShares: ControlOfSharesI
-  otherReason: string
+  otherReasons: string
   controlOfDirectors: ControlOfDirectorsI
   birthDate: string
 

--- a/btr-web/btr-main-app/utils/validation.ts
+++ b/btr-web/btr-main-app/utils/validation.ts
@@ -67,11 +67,11 @@ export function validateControlOfDirectors (formData: FormInputI): boolean {
 }
 
 /**
- * Check if the text in the 'Other Reason' textarea is less than or equal to 1000 characters
+ * Check if the text in the 'Other Reasons' textarea is less than or equal to 1000 characters
  * @param formData the form data
  */
-export function validateOtherReason (formData: FormInputI): boolean {
-  return formData.otherReason === undefined || formData.otherReason.length <= 1000
+export function validateOtherReasons (formData: FormInputI): boolean {
+  return formData.otherReasons === undefined || formData.otherReasons.length <= 1000
 }
 
 /**


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/18883

*Description of changes:*
Two bugs: 
- the checkbox for "unable to obtain and confirm information" is always unchecked when the form is loaded. (The default selection should be determined by value of 'missingInfoReason' field of the SI)
- the 'otherReason' textarea does not raise error when the input is over 1000 characters. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
