### PR TITLE
Accessibility: fix color contrast issue in the form

### DIFF
--- a/btr-web/btr-common-components/app.config.ts
+++ b/btr-web/btr-common-components/app.config.ts
@@ -11,14 +11,15 @@ export default defineAppConfig({
       }
     },
     formGroup: {
-      label: { base: 'block text-base font-bold py-3 text-gray-900' }
+      label: { base: 'block text-base font-bold py-3 text-gray-900' },
+      error: 'text-bcGovRed-500'
     },
     input: {
       base: 'bg-gray-100 hover:bg-gray-200 h-[56px] border-b-[1px] focus:border-b-2 focus:ring-0',
       rounded: 'rounded-none rounded-t-md',
       variant: {
         bcGov: 'border-gray-700 placeholder-gray-700 focus:border-primary-500 focus:placeholder-primary-500',
-        error: 'border-red-500 focus:border-red-500 placeholder-red-500 focus:placeholder-red-500',
+        error: 'border-bcGovRed-500 focus:border-bcGovRed-500 placeholder-bcGovRed-500 focus:placeholder-bcGovRed-500',
         primary: 'border-primary-500 placeholder-primary-500 border-b-2'
       }
     },
@@ -27,7 +28,7 @@ export default defineAppConfig({
       rounded: 'rounded-none rounded-t-md',
       variant: {
         bcGov: 'border-gray-700',
-        error: 'border-red-500'
+        error: 'border-bcGovRed-500'
       },
       icon: {
         base: 'text-gray-700'
@@ -53,7 +54,7 @@ export default defineAppConfig({
       rounded: 'rounded-none rounded-t-md',
       variant: {
         bcGov: 'border-gray-700 placeholder-gray-700 focus:border-primary-500 focus:placeholder-primary-500',
-        error: 'border-red-500 focus:border-red-500 placeholder-red-500 focus:placeholder-red-500'
+        error: 'border-bcGovRed-500 focus:border-bcGovRed-500 placeholder-bcGovRed-500 focus:placeholder-bcGovRed-500'
       }
     },
     table: {

--- a/btr-web/btr-common-components/components/bcros/inputs/Address/Index.vue
+++ b/btr-web/btr-common-components/components/bcros/inputs/Address/Index.vue
@@ -4,7 +4,7 @@
       <!-- country -->
       <USelectMenu
         v-model="country"
-        :ui-menu="{ placeholder: countryError ? 'text-red-500' : 'text-gray-700' }"
+        :ui-menu="{ placeholder: countryError ? 'text-bcGovRed-500' : 'text-gray-700' }"
         by="alpha_2"
         class="w-full"
         :placeholder="$t('labels.country')"
@@ -55,7 +55,7 @@
         <USelectMenu
           v-if="address.country.alpha_2==='US' || address?.country.alpha_2==='CA'"
           v-model="address.region"
-          :ui-menu="{ placeholder: regionInvalid ? 'text-red-500' : 'text-gray-700' }"
+          :ui-menu="{ placeholder: regionInvalid ? 'text-bcGovRed-500' : 'text-gray-700' }"
           :options="regions"
           :placeholder="$t('labels.state')"
           class="pr-4 w-full"

--- a/btr-web/btr-common-components/components/bcros/inputs/Address/Line1Autocomplete.vue
+++ b/btr-web/btr-common-components/components/bcros/inputs/Address/Line1Autocomplete.vue
@@ -12,7 +12,7 @@
             'text-left',
             'border-b-[1px]',
             'focus:border-b-2',
-            errorVersion ? 'border-red-500' : 'border-gray-700',
+            errorVersion ? 'border-bcGovRed-500' : 'border-gray-700',
             'focus:outline-none',
             'sm:text-sm',
             'h-[56px]',
@@ -22,7 +22,7 @@
           <ComboboxInput
             :placeholder="$t('labels.line1')"
             class="bg-transparent pl-2 w-full h-full focus:outline-none"
-            :class="errorVersion ? 'placeholder-red-500' : 'placeholder-gray-700'"
+            :class="errorVersion ? 'placeholder-bcGovRed-500' : 'placeholder-gray-700'"
             data-cy="address-street"
             @keyup="doTheSearch($event.target.value)"
             @blur="$emit('blur', $event)"

--- a/btr-web/btr-common-components/components/bcros/inputs/CountriesOfCitizenship/Index.vue
+++ b/btr-web/btr-common-components/components/bcros/inputs/CountriesOfCitizenship/Index.vue
@@ -2,7 +2,7 @@
   <div>
     <div
       class="flex flex-col py-5"
-      :class="{ 'text-red-500': hasError}"
+      :class="{ 'text-bcGovRed-500': hasError}"
       data-cy="countryOfCitizenshipRadioGroup"
     >
       <div v-for="option in options" :key="option.value" class="flex items-center mb-2 py-1">
@@ -12,7 +12,7 @@
           :value="option.value"
         />
         <label :for="`radio-${option.value}`" class="ml-5">
-          <div class="text-base" :class="hasError ? 'text-red-500' : 'text-gray-900'">
+          <div class="text-base" :class="hasError ? 'text-bcGovRed-500' : 'text-gray-900'">
             {{ option.label }}
           </div>
         </label>
@@ -26,7 +26,7 @@
         />
       </div>
     </div>
-    <div v-if="hasError" class="text-sm text-red-500">
+    <div v-if="hasError" class="text-sm text-bcGovRed-500">
       {{ errors[0].message }}
     </div>
   </div>

--- a/btr-web/btr-common-components/components/bcros/inputs/DateSelect.vue
+++ b/btr-web/btr-common-components/components/bcros/inputs/DateSelect.vue
@@ -30,7 +30,7 @@
         </PopoverPanel>
       </transition>
     </Popover>
-    <div v-if="hasError" class="py-2 text-sm text-red-500">
+    <div v-if="hasError" class="py-2 text-sm text-bcGovRed-500">
       {{ errors[0].message }}
     </div>
   </div>
@@ -70,7 +70,7 @@ const iconClass = computed(() => {
     return 'text-primary-500'
   }
   if (props.variant === 'error') {
-    return 'text-red-500'
+    return 'text-bcGovRed-500'
   }
   return 'text-gray-700'
 })

--- a/btr-web/btr-common-components/components/bcros/inputs/TextArea/Index.vue
+++ b/btr-web/btr-common-components/components/bcros/inputs/TextArea/Index.vue
@@ -7,7 +7,7 @@
       @input="$emit('update:modelValue', $event.target.value)"
     />
     <div class="w-full h-[1rem] flex justify-between">
-      <div v-if="hasError" class="text-sm text-red-500">
+      <div v-if="hasError" class="text-sm text-bcGovRed-500">
         {{ errors[0].message }}
       </div>
       <span v-if="maxChar" class="ml-auto text-sm" :class="maxCharColour">
@@ -28,6 +28,6 @@ const props = defineProps({
   errors: { type: Object as PropType<FormError[]>, default: () => ([] as FormError[]) }
 })
 
-const maxCharColour = computed(() => props.modelValue.length > props.maxChar ? 'text-red-500' : 'text-gray-700')
+const maxCharColour = computed(() => props.modelValue.length > props.maxChar ? 'text-bcGovRed-500' : 'text-gray-700')
 const hasError = computed<Boolean>(() => props.errors.length > 0)
 </script>

--- a/btr-web/btr-main-app/components/individual-person/control/ControlOfDirectors.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/ControlOfDirectors.vue
@@ -9,7 +9,7 @@
         class="py-2"
       />
     </div>
-    <div v-if="hasError" class="py-2 text-sm text-red-500">
+    <div v-if="hasError" class="py-2 text-sm text-bcGovRed-500">
       {{ errors[0].message }}
     </div>
     <UCheckbox
@@ -65,6 +65,6 @@ const types = [
 
 const controlOfDirectors: Ref<ControlOfDirectorsI> = ref(prop.modelValue)
 const hasError = computed<Boolean>(() => prop.errors.length > 0)
-const errorTextColor = computed(() => (hasError.value ? { label: 'text-red-500' } : {}))
+const errorTextColor = computed(() => (hasError.value ? { label: 'text-bcGovRed-500' } : {}))
 
 </script>

--- a/btr-web/btr-main-app/components/individual-person/control/Percentage.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/Percentage.vue
@@ -24,5 +24,5 @@ const props = defineProps({
   variant: { type: String, default: 'bcGov' }
 })
 
-const percentColour = computed(() => props.variant === 'error' ? 'text-red-500' : 'text-gray-500')
+const percentColour = computed(() => props.variant === 'error' ? 'text-bcGovRed-500' : 'text-gray-500')
 </script>

--- a/btr-web/btr-main-app/components/individual-person/control/TypeOfControl.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/TypeOfControl.vue
@@ -42,7 +42,7 @@
           class="py-2"
         />
       </div>
-      <div v-if="hasError" class="py-2 text-sm text-red-500">
+      <div v-if="hasError" class="py-2 text-sm text-bcGovRed-500">
         {{ errors[0].message }}
       </div>
     </div>
@@ -84,6 +84,6 @@ const types = [
 
 const typeOfControl: Ref<ControlOfSharesI> = ref(prop.modelValue)
 const hasError = computed<Boolean>(() => prop.errors.length > 0)
-const errorTextColor = computed(() => (hasError.value ? { label: 'text-red-500' } : {}))
+const errorTextColor = computed(() => (hasError.value ? { label: 'text-bcGovRed-500' } : {}))
 
 </script>

--- a/btr-web/btr-main-app/components/individual-person/tax-info/TaxNumber.vue
+++ b/btr-web/btr-main-app/components/individual-person/tax-info/TaxNumber.vue
@@ -27,11 +27,11 @@
         :value="NO_TAX_NUMBER"
         @change="handleRadioButtonChange(NO_TAX_NUMBER)"
       />
-      <label for="noTaxNumberRadioButton" class="ml-5" :class="{ 'text-red-500': hasError}">
+      <label for="noTaxNumberRadioButton" class="ml-5" :class="{ 'text-bcGovRed-500': hasError}">
         {{ $t('labels.noTaxNumberLabel') }}
       </label>
     </div>
-    <div v-if="hasError" class="text-sm text-red-500">
+    <div v-if="hasError" class="text-sm text-bcGovRed-500">
       {{ errors[0].message }}
     </div>
   </div>

--- a/btr-web/btr-main-app/components/individual-person/tax-info/TaxResidency.vue
+++ b/btr-web/btr-main-app/components/individual-person/tax-info/TaxResidency.vue
@@ -4,7 +4,7 @@
       v-for="(option, index) in options"
       :key="index"
       class="flex items-center mb-2 py-1"
-      :class="{ 'text-red-500': hasError}"
+      :class="{ 'text-bcGovRed-500': hasError}"
     >
       <URadio
         :id="`radio-${option.value}`"
@@ -16,7 +16,7 @@
         {{ option.label }}
       </label>
     </div>
-    <div v-if="hasError" class="text-sm text-red-500">
+    <div v-if="hasError" class="text-sm text-bcGovRed-500">
       {{ errors[0].message }}
     </div>
   </UFormGroup>


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/19689

*Description of changes:*
- Use the right red (#D3272C) for error color in the form. This removed the accessibility error for color contrast in ownerChange page. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
