### PR TITLE
Align radio top, display exteranl influence in any case.

### DIFF
--- a/btr-web/btr-main-app/components/individual-person/AddNew.vue
+++ b/btr-web/btr-main-app/components/individual-person/AddNew.vue
@@ -213,18 +213,18 @@
         <p>
           <BcrosI18HelperBold translation-path="texts.externalInfluence.text" />
         </p>
-        <div class="flex items-center mb-2 py-1">
+        <div class="flex items-top mb-2 py-1">
           <URadio
-            id="radio-can-influence"
+            id="radio-no-influence"
             v-model="significantIndividual.externalInfluence"
             :value="ExternalInfluenceE.NO_EXTERNAL_INFLUENCE"
             data-cy="external-influence-radio-no-influence"
           />
-          <label for="radio-can-influence" class="ml-5">
+          <label for="radio-no-influence" class="ml-5">
             <BcrosI18HelperBold translation-path="labels.externalInfluence.noExternalInfluence" />
           </label>
         </div>
-        <div class="flex items-center mb-2 py-1">
+        <div class="flex items-top mb-2 py-1">
           <URadio
             id="radio-can-be-influenced"
             v-model="significantIndividual.externalInfluence"
@@ -235,7 +235,7 @@
             <BcrosI18HelperBold translation-path="labels.externalInfluence.canBeInfluenced" />
           </label>
         </div>
-        <div class="flex items-center mb-2 py-1">
+        <div class="flex items-top mb-2 py-1">
           <URadio
             id="radio-can-influence"
             v-model="significantIndividual.externalInfluence"

--- a/btr-web/btr-main-app/components/individual-person/AddNew.vue
+++ b/btr-web/btr-main-app/components/individual-person/AddNew.vue
@@ -219,6 +219,7 @@
             v-model="significantIndividual.externalInfluence"
             :value="ExternalInfluenceE.NO_EXTERNAL_INFLUENCE"
             data-cy="external-influence-radio-no-influence"
+            class="pt-1"
           />
           <label for="radio-no-influence" class="ml-5">
             <BcrosI18HelperBold translation-path="labels.externalInfluence.noExternalInfluence" />
@@ -230,6 +231,7 @@
             v-model="significantIndividual.externalInfluence"
             :value="ExternalInfluenceE.CAN_BE_INFLUENCED"
             data-cy="external-influence-radio-can-be-influenced"
+            class="pt-1"
           />
           <label for="radio-can-influence" class="ml-5">
             <BcrosI18HelperBold translation-path="labels.externalInfluence.canBeInfluenced" />
@@ -241,6 +243,7 @@
             v-model="significantIndividual.externalInfluence"
             :value="ExternalInfluenceE.CAN_INFLUENCE"
             data-cy="external-influence-radio-can-influence"
+            class="pt-1"
           />
           <label for="radio-can-influence" class="ml-5">
             <BcrosI18HelperBold translation-path="labels.externalInfluence.canInfluence" />

--- a/btr-web/btr-main-app/components/individual-person/SummaryTable.vue
+++ b/btr-web/btr-main-app/components/individual-person/SummaryTable.vue
@@ -110,7 +110,7 @@
       </tr>
       <!-- standard class or css style without !important was not working -->
       <tr
-        v-if="displayAdditional(item) && editingIndex != index"
+        v-if="item.action != FilingActionE.REMOVE && editingIndex != index"
         style="border-top-width: 0!important"
         data-cy="summary-table-external-influence"
       >
@@ -118,8 +118,11 @@
           <p v-if="item.externalInfluence === ExternalInfluenceE.CAN_BE_INFLUENCED">
             {{ $t('labels.externalInfluence.canBeInfluenced') }}
           </p>
-          <p v-if="item.externalInfluence === ExternalInfluenceE.CAN_INFLUENCE">
+          <p v-else-if="item.externalInfluence === ExternalInfluenceE.CAN_INFLUENCE">
             {{ $t('labels.externalInfluence.canInfluence') }}
+          </p>
+          <p v-else>
+            {{ $t('labels.externalInfluence.noExternalInfluence') }}
           </p>
         </td>
       </tr>
@@ -187,16 +190,6 @@ const headers = [
 const isEmptyState = computed(() => {
   return props.individuals.every(individual => individual.action === FilingActionE.REMOVE)
 })
-
-const displayAdditional = (item: SignificantIndividualI) => {
-  return (
-    item.action !== FilingActionE.REMOVE &&
-    (
-      item.externalInfluence === ExternalInfluenceE.CAN_INFLUENCE ||
-      item.externalInfluence === ExternalInfluenceE.CAN_BE_INFLUENCED
-    )
-  )
-}
 
 function getTaxResidentText (isTaxResident: boolean) {
   if (isTaxResident) {


### PR DESCRIPTION
*Issue:18668*https://github.com/bcgov/entity/issues/18668

*Description of changes:*
- ux changes for 18668
  - aligning radios to top
  - displaying "external influence" info always in summary table

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
