### PR TITLE
Fix AA issues for citizenship dropdown and breadcrumb

### DIFF
--- a/btr-web/btr-common-components/components/bcros/inputs/CountriesOfCitizenship/Dropdown.vue
+++ b/btr-web/btr-common-components/components/bcros/inputs/CountriesOfCitizenship/Dropdown.vue
@@ -22,6 +22,7 @@
       <ComboboxButton
         class="w-full h-full px-[10px] text-left"
         data-cy="countryOfCitizenshipDropdownButton"
+        tabindex="0"
       >
         <span
           v-if="nonCaCitizenships.length === 0"
@@ -48,66 +49,64 @@
         <UIcon class="float-right text-2xl " name="i-mdi-chevron-down" />
       </ComboboxButton>
       <div v-show="open" class="absolute z-10 w-full">
-        <ul>
-          <ComboboxInput
-            :placeholder="$t('labels.countryOfCitizenship.findCountry')"
-            :class="[
-              'w-full',
-              'focus:outline-none',
-              'sm:text-sm',
-              'p-3',
-              'bg-gray-100',
-              'border-b-2',
-              'border-primary-500',
-              'placeholder-primary-500'
-            ]"
-            data-cy="countryOfCitizenshipDropdownFilter"
-            @change="filterCountries($event.target.value)"
-          />
-          <ComboboxOptions
-            :class="[
-              'relative',
-              'max-h-60',
-              'w-full',
-              'overflow-auto',
-              'bg-white',
-              'py-1',
-              'text-base',
-              'shadow-lg',
-              'focus:outline-none',
-              'sm:text-sm',
-              'bg-gray-500',
-              'z-10'
-            ]"
-            as="div"
+        <ComboboxInput
+          :placeholder="$t('labels.countryOfCitizenship.findCountry')"
+          :class="[
+            'w-full',
+            'focus:outline-none',
+            'sm:text-sm',
+            'p-3',
+            'bg-gray-100',
+            'border-b-2',
+            'border-primary-500',
+            'placeholder-primary-500'
+          ]"
+          data-cy="countryOfCitizenshipDropdownFilter"
+          @change="filterCountries($event.target.value)"
+        />
+        <ComboboxOptions
+          :class="[
+            'relative',
+            'max-h-60',
+            'w-full',
+            'overflow-auto',
+            'bg-white',
+            'py-1',
+            'text-base',
+            'shadow-lg',
+            'focus:outline-none',
+            'sm:text-sm',
+            'bg-gray-500',
+            'z-10'
+          ]"
+          as="div"
+        >
+          <ComboboxOption
+            v-for="country in countriesWithoutCa"
+            :key="country.alpha_2"
+            v-slot="{ active }"
+            :value="country"
+            as="template"
           >
-            <ComboboxOption
-              v-for="country in countriesWithoutCa"
-              :key="country.alpha_2"
-              v-slot="{ active }"
-              :value="country"
-              as="template"
+            <div
+              class="cursor-default select-none py-2 pl-10 pr-4"
+              :class="{ 'bg-gray-100': active }"
+              data-cy="countryOfCitizenshipDropdownOption"
             >
-              <li
-                class="cursor-default select-none py-2 pl-10 pr-4"
-                :class="{ 'bg-gray-100': active }"
-                data-cy="countryOfCitizenshipDropdownOption"
-              >
-                <span v-if="isInSelected(country)" class="float-right text-outcomes-success">
-                  <UIcon name="i-mdi-check" />
-                  {{ $t('labels.countryOfCitizenship.selected') }}
-                </span>
-                <span v-else class="float-right text-primary">
-                  <UIcon name="i-mdi-add" />
-                  {{ $t('labels.countryOfCitizenship.select') }}
-                </span>
-                <span>
-                  {{ country.name }}
-                </span>
-              </li>
-            </ComboboxOption>
-          </ComboboxOptions>
-        </ul>
+              <span v-if="isInSelected(country)" class="float-right text-outcomes-success">
+                <UIcon name="i-mdi-check" />
+                {{ $t('labels.countryOfCitizenship.selected') }}
+              </span>
+              <span v-else class="float-right text-primary">
+                <UIcon name="i-mdi-add" />
+                {{ $t('labels.countryOfCitizenship.select') }}
+              </span>
+              <span>
+                {{ country.name }}
+              </span>
+            </div>
+          </ComboboxOption>
+        </ComboboxOptions>
       </div>
     </Combobox>
   </div>

--- a/btr-web/btr-layouts/components/bcros/Breadcrumb.vue
+++ b/btr-web/btr-layouts/components/bcros/Breadcrumb.vue
@@ -6,6 +6,7 @@
         color="white"
         :disabled="breadcrumbs.length < 2"
         icon="i-mdi-arrow-left"
+        aria-label="back"
         data-cy="crumb-back"
         @click="back()"
       />

--- a/btr-web/btr-main-app/components/individual-person/control/Percentage.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/Percentage.vue
@@ -24,5 +24,5 @@ const props = defineProps({
   variant: { type: String, default: 'bcGov' }
 })
 
-const percentColour = computed(() => props.variant === 'error' ? 'text-red-500' : 'text-gray-500')
+const percentColour = computed(() => props.variant === 'error' ? 'text-red-500' : 'text-gray-700')
 </script>

--- a/btr-web/btr-main-app/components/individual-person/control/UnableToObtainOrConfirmInformation.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/UnableToObtainOrConfirmInformation.vue
@@ -60,8 +60,10 @@ const isUnableToObtainOrConfirmInformationCheckboxChange = () => {
     isUnableToObtainOrConfirmInformationDetails.value = ''
   }
 }
-const isUnableToObtainOrConfirmInformationDetailsKeyDown = () => {
-  isUnableToObtainOrConfirmInformation.value = true
+const isUnableToObtainOrConfirmInformationDetailsKeyDown = (event: KeyboardEvent) => {
+  if (event.key !== 'Tab') {
+    isUnableToObtainOrConfirmInformation.value = true
+  }
 }
 
 watch(isUnableToObtainOrConfirmInformation, (newValue) => {

--- a/btr-web/btr-main-app/cypress/e2e/accessibility/layouts.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/accessibility/layouts.cy.ts
@@ -36,7 +36,7 @@ describe('accessibility -> Business Layout', () => {
     cy.checkA11y({ exclude: ['[data-cy=owner-change]'], include: ['[data-cy=header]'] })
 
     // breadcrumb only 19579
-    // cy.checkA11y({ exclude: ['[data-cy=owner-change]'], include: ['[data-cy=breadcrumb]'] })
+    cy.checkA11y({ exclude: ['[data-cy=owner-change]'], include: ['[data-cy=breadcrumb]'] })
 
     // business details only
     cy.checkA11y({ exclude: ['[data-cy=owner-change]'], include: ['[data-cy=business-details]'] })

--- a/btr-web/btr-main-app/cypress/e2e/accessibility/ownerChange.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/accessibility/ownerChange.cy.ts
@@ -73,22 +73,20 @@ describe('accessibility -> Beneficial Owner Change', () => {
 
     // Expanding the form - dynamic elements 19443
     // address line 1 expansion
-    // cy.get('[data-cy=add-new-btn]').click()
-    // cy.get('[data-cy=address-line1-autocomplete]').type('123')
-    // cy.checkA11y('[data-cy=address-street-options]')
+    cy.get('[data-cy=add-new-btn]').click()
+    cy.get('[data-cy=address-line1-autocomplete]').type('123')
+    cy.checkA11y('[data-cy=address-street-options]')
     // countries of citizenship dropdown
-    // cy.get('[data-cy=add-new-btn]').click()
-    // cy.get('[data-cy=address-line1-autocomplete]').type('123')
-    // cy.get('[data-cy=countryOfCitizenshipRadioGroup]').get('[type=radio][value=other]').check()
-    // cy.checkA11y('[data-cy=countryOfCitizenshipDropdown]')
-    // cy.get('[data-cy=countryOfCitizenshipDropdownButton]').click()
-    // cy.get('[data-cy=countryOfCitizenshipDropdownOption]').eq(0).click({ force: true })
-    // cy.get('[data-cy=countryOfCitizenshipDropdownOption]').eq(4).click({ force: true })
-    // cy.checkA11y('[data-cy=countryOfCitizenshipDropdown]')
+    cy.get('[data-cy=address-line1-autocomplete]').type('123')
+    cy.get('[data-cy=countryOfCitizenshipRadioGroup]').get('[type=radio][value=other]').check()
+    cy.checkA11y('[data-cy=countryOfCitizenshipDropdown]')
+    cy.get('[data-cy=countryOfCitizenshipDropdownButton]').click()
+    cy.get('[data-cy=countryOfCitizenshipDropdownOption]').eq(0).click({ force: true })
+    cy.get('[data-cy=countryOfCitizenshipDropdownOption]').eq(4).click({ force: true })
+    cy.checkA11y('[data-cy=countryOfCitizenshipDropdown]')
     // not possible to obtain data checkbox clicked
-    // cy.get('[data-cy=add-new-btn]').click()
-    // cy.get('[data-cy=isUnableToObtainOrConfirmInformationCheckbox]').check()
-    // cy.checkA11y('[data-cy=isUnableToObtainOrConfirmInformation]')
+    cy.get('[data-cy=isUnableToObtainOrConfirmInformationCheckbox]').check()
+    cy.checkA11y('[data-cy=isUnableToObtainOrConfirmInformation]')
 
     // NB: uncomment once all above are passing
     // cy.checkA11y('[data-cy=owner-change]')


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/19443
*Issue:*https://github.com/bcgov/entity/issues/19579

*Description of changes:*
- fix the list structure AA issue in the citizenship dropdown
- ensure we can tab into the dropdown and make selection
- update gray color for '%' in percentOfShares and percentOfVotes (ticket #19689)
- fix the 'button-name' AA error in the breadcrumb

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
