### PR TITLE
Fix validation logic for percentage of shares and votes

### DIFF
--- a/btr-web/btr-main-app/components/individual-person/AddNew.vue
+++ b/btr-web/btr-main-app/components/individual-person/AddNew.vue
@@ -463,12 +463,18 @@ watch(
       removeEmptyPercentageErrors()
     }
 
-    // If the percentOfShares and percentOfVotes are < 25%, and the "in-concert control" checkbox is not checked,
+    // If percentOfShares + percentOfVotes are < 25%, and the "in-concert control" checkbox is not checked,
     // the type of control error should be remove as this field is now optional
-    const shares = parseInt(values[0])
-    const votes = parseInt(values[1])
-    if ((Number.isNaN(shares) || shares < 25) && (Number.isNaN(votes) || votes < 25) &&
-      !significantIndividual.value.controlType.sharesVotes.inConcertControl) {
+    const shares = Number(values[0])
+    const votes = Number(values[1])
+    let total = 0
+    if (!Number.isNaN(shares)) {
+      total += shares
+    }
+    if (!Number.isNaN(votes)) {
+      total += votes
+    }
+    if (total < 25 && !significantIndividual.value.controlType.sharesVotes.inConcertControl) {
       controlOfSharesErrors.value = []
     }
   }
@@ -489,10 +495,17 @@ watch(
 
     // When the "in-concert control" checkbox is unchecked
     if (!values[3]) {
-      const shares = parseInt(significantIndividual.value.percentOfShares)
-      const votes = parseInt(significantIndividual.value.percentOfVotes)
-      // if the percentOfShares and percentOfVotes are < 25%, remove the type of control error
-      if ((Number.isNaN(shares) || shares < 25) && (Number.isNaN(votes) || votes < 25)) {
+      const shares = Number(significantIndividual.value.percentOfShares)
+      const votes = Number(significantIndividual.value.percentOfVotes)
+      // if percentOfShares + percentOfVotes are < 25%, remove the type of control error
+      let total = 0
+      if (!Number.isNaN(shares)) {
+        total += shares
+      }
+      if (!Number.isNaN(votes)) {
+        total += votes
+      }
+      if (total < 25) {
         controlOfSharesErrors.value = []
       }
 

--- a/btr-web/btr-main-app/cypress/e2e/pages/formValidation.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/pages/formValidation.cy.ts
@@ -92,13 +92,14 @@ describe('pages -> Form Validation', () => {
     cy.contains(i18n.errors.validation.controlPercentage.empty).should('not.exist')
     cy.contains(i18n.errors.validation.controlOfDirectors.required).should('not.exist')
 
-    // if either the percent of shares or the percent of votes is >= 25%, the control type is required
+    // if the combination of share percentage and vote percentage is >= 25%, the control type is required
     cy.get('[data-cy=new-si-cancel-btn]').click()
     cy.get('[data-cy=add-new-btn]').click()
     cy.get('[name="percentOfShares"]').type('10').blur()
+    cy.get('[name="percentOfVotes"]').type('14').blur()
     cy.get('[data-cy=new-si-done-btn]').click()
     cy.contains(i18n.errors.validation.controlOfDirectors.required).should('not.exist')
-    cy.get('[name="percentOfShares"]').clear().type('30').blur()
+    cy.get('[name="percentOfVotes"]').clear().type('15').blur()
     cy.get('[data-cy=new-si-done-btn]').click()
     cy.contains(i18n.errors.validation.controlOfDirectors.required).should('exist')
     cy.get('[name="registeredOwner"]').check()

--- a/btr-web/btr-main-app/utils/validation.ts
+++ b/btr-web/btr-main-app/utils/validation.ts
@@ -46,7 +46,7 @@ export function validateSharesAndVotes (formData: FormInputI): boolean {
 
 /**
  * Validate the Type of Control checkboxes. Return false when type of control is required but no selections are made.
- * Case 1: If the percentage of shares or votes is >= 25%, at least one of the Type of Control checkboxes is required.
+ * Case 1: If the combination of shares and votes is >= 25%, at least one of the Type of Control checkboxes is required.
  * Case 2: If the 'exercised in concert'is selected, at least one of the Type of Control checkboxes is required.
  * @param formData the form data
  */
@@ -56,7 +56,7 @@ export function validateControlOfShares (formData: FormInputI): boolean {
   const percentOfShares: number = Number(formData.percentOfShares)
   const percentOfVotes: number = Number(formData.percentOfVotes)
 
-  if (percentOfShares >= 25 || percentOfVotes >= 25 || inConcertControlSelected) {
+  if (percentOfShares + percentOfVotes >= 25 || inConcertControlSelected) {
     return typeOfControlSelected
   } else {
     return true


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/19859

*Description of changes:*
If the combination of shares and votes is >= 25%, the type of control field is required.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
