### PR TITLE
allow unselect of percentage and add test case to cover

### DIFF
--- a/btr-web/btr-main-app/components/individual-person/control/PercentageSelector.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/PercentageSelector.vue
@@ -48,6 +48,11 @@ if (model.value) {
 }
 
 const selectOption = (index: number) => {
+  if (selected.value === index) {
+    selected.value = -1
+    model.value = 'noSelection'
+    return
+  }
   selected.value = index
   model.value = options[index].range
   formBus?.emit({ type: 'blur', path: props.name })

--- a/btr-web/btr-main-app/cypress/e2e/pages/add-individual/control-of-shares-and-votes.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/pages/add-individual/control-of-shares-and-votes.cy.ts
@@ -19,9 +19,11 @@ describe('pages -> Add individual', () => {
 
   const verifyBgColorsControlOfVotes = (index: number) => {
     const nonSelected = [0, 1, 2, 3].filter(num => num !== index)
-    cy.get(`[data-cy="controlOfVotes.percentage.${index}"]`)
-      .should('have.css', 'background-color')
-      .and('eq', 'rgb(22, 105, 187)')
+    if (index !== -1) {
+      cy.get(`[data-cy="controlOfVotes.percentage.${index}"]`)
+        .should('have.css', 'background-color')
+        .and('eq', 'rgb(22, 105, 187)')
+    }
     nonSelected.forEach((num) => {
       cy.get(`[data-cy="controlOfVotes.percentage.${num}"]`)
         .should('have.css', 'background-color')
@@ -41,5 +43,9 @@ describe('pages -> Add individual', () => {
     verifyBgColorsControlOfVotes(2)
     cy.get('[data-cy="controlOfVotes.percentage.3"]').click()
     verifyBgColorsControlOfVotes(3)
+
+    //test can unselect
+    cy.get('[data-cy="controlOfVotes.percentage.3"]').click()
+    verifyBgColorsControlOfVotes(-1)
   })
 })

--- a/btr-web/btr-main-app/cypress/e2e/pages/add-individual/control-of-shares-and-votes.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/pages/add-individual/control-of-shares-and-votes.cy.ts
@@ -44,7 +44,7 @@ describe('pages -> Add individual', () => {
     cy.get('[data-cy="controlOfVotes.percentage.3"]').click()
     verifyBgColorsControlOfVotes(3)
 
-    //test can unselect
+    // test can unselect
     cy.get('[data-cy="controlOfVotes.percentage.3"]').click()
     verifyBgColorsControlOfVotes(-1)
   })


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/21612

*Description of changes:*
Modified select function to unselect if same button is clicked, tested to ensure the note when visible also disappears properly. Added test case to cypress

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
