### PR TITLE
changes to redaction

### DIFF
--- a/btr-api/src/btr_api/enums/redaction_types.py
+++ b/btr-api/src/btr_api/enums/redaction_types.py
@@ -20,6 +20,7 @@ class RedactionType(BaseEnum):
 
     REDACT_MONONYM = 'mono'
     REDACT_MONONYM_FN = 'mono_fn'
+    REDACT_MONONYM_LN = 'mono_ln'
     REDACT_EMAIL = 'mono_email'
     REDACT_PHONE = 'mono_phone'
     REDACT_FULL = 'full'

--- a/btr-api/src/btr_api/services/auth.py
+++ b/btr-api/src/btr_api/services/auth.py
@@ -146,7 +146,7 @@ class AuthService:
 
         return authorization_header
 
-    # @auth_cache.cached(timeout=600, make_cache_key=get_cache_key, cache_none=False)
+    @auth_cache.cached(timeout=600, make_cache_key=get_cache_key, cache_none=False)
     def product_authorizations(self, request, account_id: str) -> None:
         """Get the products associated with the user and account_id."""
         if not account_id:


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/23402

*Description of changes:*
Redaction is now the same (currently) across Staff and Public. The rules have also changed to match the spreadsheet in the ticket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
