### PR TITLE
23592 - fix: unable to update other citizenship for existing SI

### DIFF
--- a/btr-web/btr-main-app/components/individual-person/citizenship/index.vue
+++ b/btr-web/btr-main-app/components/individual-person/citizenship/index.vue
@@ -52,6 +52,11 @@ const updateCitizenship = () => {
   formBus?.emit({ type: 'change', path: props.name })
 }
 
+watch(otherCitizenships, () => {
+  if (citizenshipSelector.value === CitizenshipSelectorE.OTHER) {
+    updateCitizenship()
+  }
+})
 </script>
 
 <template>


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/23592

*Description of changes:*
The issue (invalid schema for nationalities) mentioned in ticket 23592 is outdated. That might have been fixed already. 
Existing bug that is tackled in this PR:
- When we edit an SI who has other citizenship, any update made to the other citizenship section (e.g., deleting or selecting countries) does not exist in the submission payload. It is not picked up by `newOrUpdatedFields`
- some reactivity issue; when we unselect a citizenship option by clicking 'X' at the chip, this change is not picked up by the parent component  --- should be fixed now. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
