### PR TITLE
API - authorizations test fix/add

### DIFF
--- a/btr-api/src/btr_api/resources/submission.py
+++ b/btr-api/src/btr_api/resources/submission.py
@@ -69,7 +69,7 @@ def registers(id: int | None = None):  # pylint: disable=redefined-builtin
     try:
         if submission := SubmissionModel.find_by_id(id):
             account_id = request.headers.get('Account-Id', None)
-            btr_auth.is_authorized(request=request, business_identifier=submission.business_identifier)
+            btr_auth.is_authorized(request=request, business_identifier=submission.business_identifier, action='view')
             btr_auth.product_authorizations(request=request, account_id=account_id)
             redacted = redact_information(SubmissionSerializer.to_dict(submission), btr_auth.get_user_type())
             return jsonify(type=submission.type, submission=redacted['payload'])
@@ -88,7 +88,7 @@ def get_entity_submission(business_identifier: str):
     """Get the current submission for specified business identifier."""
 
     try:
-        btr_auth.is_authorized(request=request, business_identifier=business_identifier)
+        btr_auth.is_authorized(request=request, business_identifier=business_identifier, action='view')
         account_id = request.headers.get('Account-Id', None)
         btr_auth.product_authorizations(request=request, account_id=account_id)
 
@@ -128,8 +128,7 @@ def create_register():
             return error_request_response('Invalid schema', HTTPStatus.BAD_REQUEST, errors)
 
         business_identifier = json_input.get('businessIdentifier')
-        btr_auth.is_authorized(request=request, business_identifier=business_identifier)
-
+        btr_auth.is_authorized(request=request, business_identifier=business_identifier, action='edit')
         # get entity
         token = btr_auth.get_bearer_token()
         entity: dict = btr_entity.get_entity_info(None, business_identifier, token).json()
@@ -191,7 +190,7 @@ def update_submission(sub_id: int):
         submission = SubmissionModel.find_by_id(sub_id)
         if submission:
             business_identifier = submission.business_identifier
-            btr_auth.is_authorized(request=request, business_identifier=business_identifier)
+            btr_auth.is_authorized(request=request, business_identifier=business_identifier, action='edit')
             btr_auth.product_authorizations(request=request, account_id=account_id)
 
             # get entity

--- a/btr-api/src/btr_api/services/auth.py
+++ b/btr-api/src/btr_api/services/auth.py
@@ -201,7 +201,7 @@ class AuthService:
             return
 
     @auth_cache.cached(timeout=600, make_cache_key=get_cache_key, cache_none=False)
-    def is_authorized(self, request: Request, business_identifier: str) -> bool:
+    def is_authorized(self, request: Request, business_identifier: str, action: str) -> bool:
         """Authorize the user for access to the service."""
         try:
             auth_token = self.get_authorization_header(request)
@@ -216,7 +216,7 @@ class AuthService:
                 self.app.logger.debug('Invalid response from auth-api: %s', error)
                 raise ExternalServiceException(error=error, status_code=HTTPStatus.SERVICE_UNAVAILABLE)
 
-            if resp.status_code != HTTPStatus.OK or 'edit' not in resp.json().get('roles', []):
+            if resp.status_code != HTTPStatus.OK or action not in resp.json().get('roles', []):
                 error = f'Unauthorized access to business: {business_identifier}'
                 self.app.logger.debug(error)
                 raise AuthException(error=error, status_code=HTTPStatus.FORBIDDEN)


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/25680

*Description of changes:*
- my previous change had fixed the auth caching which was causing the test over authorizations to fail (happy path was cached, so I had commented it out to get it in pre-demo)
- ended up looking deeper into it and tweaking it a bit and improving the testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
