### PR TITLE
Updated SI zod Schema to support editing existing SI when missingInfo is selected

### DIFF
--- a/btr-web/btr-main-app/components/individual-person/add-new/index.vue
+++ b/btr-web/btr-main-app/components/individual-person/add-new/index.vue
@@ -672,7 +672,7 @@ const MailingAddressSchemaEdit = z.discriminatedUnion(
 const SiSchemaAddNew = SiSchema.extend({
   couldNotProvideMissingInfo: z.literal(false),
   name: SiNameExtended,
-  isControlSelected: z.boolean().refine((val) => { return !!val }, t('errors.validation.control')),
+  isControlSelected: z.boolean().refine(val => val, t('errors.validation.control')),
   controlOfShares: SiControlOfExtended,
   controlOfVotes: SiControlOfExtended,
   controlOfDirectors: SiControlOfDirectorsExtended,
@@ -707,7 +707,7 @@ let formSchema: any = z.discriminatedUnion('couldNotProvideMissingInfo', [
 
 if (props.editMode) {
   // used in the edit form; some fields are optional to support redacted data
-  const SiSchemaEdit: SiSchemaType = SiSchemaAddNew.extend({
+  const SiSchemaEdit = SiSchemaAddNew.extend({
     couldNotProvideMissingInfo: z.literal(false),
     birthDate: z.string().optional(),
     name: SiNameExtended,

--- a/btr-web/btr-main-app/components/individual-person/add-new/index.vue
+++ b/btr-web/btr-main-app/components/individual-person/add-new/index.vue
@@ -672,10 +672,7 @@ const MailingAddressSchemaEdit = z.discriminatedUnion(
 const SiSchemaAddNew = SiSchema.extend({
   couldNotProvideMissingInfo: z.literal(false),
   name: SiNameExtended,
-  isControlSelected: z.boolean().refine((val) => {
-    console.log("VALIDATING CONTROL SELECTION", val)
-    return !!val
-  }, t('errors.validation.control') + 'MMMMM'),
+  isControlSelected: z.boolean().refine((val) => { return !!val }, t('errors.validation.control')),
   controlOfShares: SiControlOfExtended,
   controlOfVotes: SiControlOfExtended,
   controlOfDirectors: SiControlOfDirectorsExtended,

--- a/btr-web/btr-main-app/components/individual-person/add-new/index.vue
+++ b/btr-web/btr-main-app/components/individual-person/add-new/index.vue
@@ -509,15 +509,15 @@
 </template>
 
 <script setup lang="ts">
-import { type RefinementCtx, z } from 'zod'
+import { z } from 'zod'
 import type { FormError } from '#ui/types'
 import type { BtrCountryI } from '../../../../btr-common-components/interfaces/btr-address-i'
-import { validateEmailRfc6532Regex } from '../../../../btr-common-components/utils'
 import {
   validateControlSelectionForSharesAndVotes,
   validateNameSuperRefineAddForm,
   validateTaxNumberInfo,
-  validateCitizenshipSuperRefine
+  validateCitizenshipSuperRefine,
+  validateEditFormSchemaSuperRefine
 } from '~/utils/validation'
 import {
   AddressSchema,
@@ -570,14 +570,14 @@ const declarationError = ref(false)
 
 const emailFieldUuid = getRandomUuid()
 const clearEmailFieldOnEdit = () => {
-  if (isEditing) {
+  if (isEditing.value) {
     setFieldOriginalValue(emailFieldUuid, inputFormSi.email)
     inputFormSi.email = ''
   }
 }
 const revertUnchangedEmailField = () => {
   const originalValue = getFieldOriginalValue(emailFieldUuid)
-  if (isEditing && !hasFieldChanged(inputFormSi, InputFieldsE.EMAIL) && originalValue) {
+  if (isEditing.value && !hasFieldChanged(inputFormSi, InputFieldsE.EMAIL) && originalValue) {
     inputFormSi.email = originalValue
   }
 }
@@ -613,19 +613,26 @@ const onNameFocus = () => {
   }
 }
 
-// extend existing schema with
+// ============== extend existing schemas ==============
+// add custom validation rules to each field; create three versions of schemas (add-new, edit, missing-info)
+
 const SiControlOfExtended = SiControlOfSchema.superRefine(validateControlSelectionForSharesAndVotes)
 const SiNameExtended = SiNameSchema.superRefine(validateNameSuperRefineAddForm)
+const SiControlOfDirectorsExtended = SiControlOfDirectorsSchema.superRefine(validateControlOfDirectors)
 
-const AddressSchemaExtended = AddressSchema.extend({
+const AddressSchemaAddNew = AddressSchema.extend({
   country: CountrySchema
     .optional()
     .refine((val: BtrCountryI | undefined) => {
       return val && val.name !== ''
-    }, t('errors.validation.address.country'))
+    }, t('errors.validation.address.country')),
+  line1: z.string().min(1),
+  city: z.string().min(1),
+  region: z.string().min(1),
+  postalCode: z.string().min(1)
 })
 
-const AddressSchemaExtendedEdit = AddressSchemaExtended.extend({
+const AddressSchemaEdit = AddressSchemaAddNew.extend({
   line1: z.string().optional(),
   postalCode: z.string().optional(),
   locationDescription: z.string().optional()
@@ -633,16 +640,16 @@ const AddressSchemaExtendedEdit = AddressSchemaExtended.extend({
 
 z.setErrorMap(CustomSiSchemaErrorMap)
 
-const MailingAddressSchema = z.discriminatedUnion(
+const MailingAddressSchemaAddNew = z.discriminatedUnion(
   'isDifferent',
   [
     z.object({
       isDifferent: z.literal(false),
-      address: AddressSchemaExtended.optional()
+      address: AddressSchemaAddNew.optional()
     }),
     z.object({
       isDifferent: z.literal(true),
-      address: AddressSchemaExtended
+      address: AddressSchemaAddNew
     })
   ]
 )
@@ -652,30 +659,76 @@ const MailingAddressSchemaEdit = z.discriminatedUnion(
   [
     z.object({
       isDifferent: z.literal(false),
-      address: AddressSchemaExtendedEdit.optional()
+      address: AddressSchemaEdit.optional()
     }),
     z.object({
       isDifferent: z.literal(true),
-      address: AddressSchemaExtendedEdit
+      address: AddressSchemaEdit
     })
   ]
 )
 
-const SiSchemaExtended = SiSchema.extend({
+// used in the add-new form; all fields are required with full custom validation
+const SiSchemaAddNew = SiSchema.extend({
   couldNotProvideMissingInfo: z.literal(false),
   name: SiNameExtended,
-  isControlSelected: z.boolean().refine(val => val, t('errors.validation.control')),
+  isControlSelected: z.boolean().refine((val) => {
+    console.log("VALIDATING CONTROL SELECTION", val)
+    return !!val
+  }, t('errors.validation.control') + 'MMMMM'),
   controlOfShares: SiControlOfExtended,
   controlOfVotes: SiControlOfExtended,
-  controlOfDirectors:
-    SiControlOfDirectorsSchema.refine(validateControlOfDirectors, getMissingControlOfDirectorsError()),
+  controlOfDirectors: SiControlOfDirectorsExtended,
   email: getEmailValidator(),
-  address: AddressSchemaExtended,
+  phoneNumber: getPhoneNumberValidator(),
+  address: AddressSchemaAddNew,
   citizenships: CitizenshipSchema.superRefine(validateCitizenshipSuperRefine),
-  mailingAddress: MailingAddressSchema,
+  mailingAddress: MailingAddressSchemaAddNew,
   tax: TaxSchema.superRefine(validateTaxNumberInfo),
   isTaxResident: z.boolean()
 })
+
+// bare minimum fields required to submit the form when missing-info checkbox is selected
+const SiSchemaMissingInfo = SiSchema.extend({
+  couldNotProvideMissingInfo: z.literal(true),
+  missingInfoReason: z.string().transform(s => s.trim()).pipe(z.string().min(1)),
+  name: SiNameExtended,
+  effectiveDates: z.array(z.object({
+    startDate: z.string().optional(),
+    endDate: z.string().optional()
+  })).optional(),
+  birthDate: z.string().optional(),
+  ui: z.object({
+    newOrUpdatedFields: z.array(z.string())
+  })
+})
+
+let formSchema: any = z.discriminatedUnion('couldNotProvideMissingInfo', [
+  SiSchemaMissingInfo,
+  SiSchemaAddNew
+])
+
+if (props.editMode) {
+  // used in the edit form; some fields are optional to support redacted data
+  const SiSchemaEdit: SiSchemaType = SiSchemaAddNew.extend({
+    couldNotProvideMissingInfo: z.literal(false),
+    birthDate: z.string().optional(),
+    name: SiNameExtended,
+    address: AddressSchemaEdit,
+    mailingAddress: MailingAddressSchemaEdit,
+    tax: TaxSchema,
+    email: z.string().optional()
+  })
+
+  formSchema = z.discriminatedUnion('couldNotProvideMissingInfo', [
+    SiSchemaEdit,
+    SiSchemaMissingInfo
+  ]).superRefine(validateEditFormSchemaSuperRefine)
+}
+
+// ============== extend schema end =============
+
+const addIndividualForm = ref()
 
 const isControlSelected = computed(() => {
   const isSelected = (control: any) => {
@@ -695,148 +748,6 @@ const isControlSelected = computed(() => {
     isSelected(inputFormSi.controlOfVotes) ||
     isSelected(inputFormSi.controlOfDirectors)
 })
-
-watch(isControlSelected, (newValue) => {
-  inputFormSi.isControlSelected = newValue
-  if (!newValue) {
-    addIndividualForm.value?.setErrors([{
-      message: t('errors.validation.control'),
-      path: 'isControlSelected'
-    }], 'isControlSelected')
-  } else {
-    addIndividualForm.value?.clear('isControlSelected')
-  }
-})
-
-let formSchema: any = z.discriminatedUnion('couldNotProvideMissingInfo', [
-  z.object({
-    couldNotProvideMissingInfo: z.literal(true),
-    missingInfoReason: z.string().transform(s => s.trim()).pipe(z.string().min(1)),
-    name: SiNameExtended,
-    ui: z.object({
-      newOrUpdatedFields: z.array(z.string())
-    })
-
-  }),
-  SiSchemaExtended
-])
-
-if (props.editMode) {
-  const SiSchemaExtendedEdit = SiSchemaExtended.extend({
-    birthDate: z.string().optional(),
-    name: SiNameExtended,
-    address: AddressSchemaExtendedEdit,
-    mailingAddress: MailingAddressSchemaEdit,
-    tax: TaxSchema,
-    email: z.string().optional()
-  })
-
-  formSchema = z.discriminatedUnion('couldNotProvideMissingInfo', [
-    z.object({
-      couldNotProvideMissingInfo: z.literal(true),
-      missingInfoReason: z.string().transform(s => s.trim()).pipe(z.string().min(1)),
-      name: SiNameExtended,
-      ui: z.object({
-        newOrUpdatedFields: z.array(z.string())
-      })
-    }),
-    SiSchemaExtendedEdit
-  ]).superRefine((schema: SiSchemaType, ctx: RefinementCtx): never => {
-    // this superRefine is to work out through the redacted data fields and validate them only on change
-    // birthdate check
-    if (schema.ui.newOrUpdatedFields.includes(InputFieldsE.BIRTH_DATE)) {
-      if (!schema.birthDate || schema.birthDate.trim() === '') {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['birthDate'],
-          message: t('errors.validation.birthDate.required')
-        })
-      }
-    }
-    // phone check // its already optional nothing to do here
-
-    // street address
-    if (schema.ui.newOrUpdatedFields.includes(InputFieldsE.ADDRESS_LINE1)) {
-      if (!schema.address || !schema.address.line1 || schema.address.line1.trim() === '') {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['address', 'line1'],
-          message: t('errors.validation.address.line1')
-        })
-      }
-    }
-    // postal code
-    if (schema.ui.newOrUpdatedFields.includes(InputFieldsE.ADDRESS_POSTAL_CODE)) {
-      if (!schema.address || !schema.address.postalCode || schema.address.postalCode.trim() === '') {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['address', 'postalCode'],
-          message: t('errors.validation.address.postalCode')
-        })
-      }
-    }
-    // location description // its already optional nothing to do here
-    if (schema.ui.newOrUpdatedFields.includes(InputFieldsE.MAILING_ADDRESS_LINE1)) {
-      if (!schema.mailingAddress.address ||
-        !schema.mailingAddress.address.line1 ||
-        schema.mailingAddress.address.line1.trim() === ''
-      ) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['mailingAddress', 'address', 'line1'],
-          message: t('errors.validation.address.line1')
-        })
-      }
-    }
-    // postal code
-    if (schema.ui.newOrUpdatedFields.includes(InputFieldsE.MAILING_ADDRESS_POSTAL_CODE)) {
-      if (!schema.mailingAddress.address ||
-        !schema.mailingAddress.address.postalCode ||
-        schema.mailingAddress.address.postalCode.trim() === ''
-      ) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['mailingAddress', 'address', 'postalCode'],
-          message: t('errors.validation.address.postalCode')
-        })
-      }
-    }
-
-    // SIN
-    if (schema.ui.newOrUpdatedFields.includes(InputFieldsE.TAX_NUMBER)) {
-      // add tax to path, so that subsequent tax validator creates erroro messages with path
-      ctx.path.push('tax')
-      validateTaxNumberInfo(schema.tax, ctx)
-      // remove tax from path so it does not add it in next ctx errors
-      const taxPath = ctx.path.findIndex(v => v === 'tax')
-      if (taxPath !== -1) {
-        ctx.path.splice(taxPath, 1)
-      }
-    }
-
-    // email
-    if (schema.ui.newOrUpdatedFields.includes(InputFieldsE.EMAIL)) {
-      if (!schema.email || schema.email.trim() === '') {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['email'],
-          message: t('errors.validation.email.empty')
-        })
-      }
-      if (!validateEmailRfc6532Regex(schema.email)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['email'],
-          message: t('errors.validation.email.invalid')
-        })
-      }
-    }
-    return z.NEVER
-  })
-}
-// extend schema end
-
-const addIndividualForm = ref()
 
 const formChange = async () => {
   await addBtrPayFees()
@@ -1001,6 +912,19 @@ watch(inputFormSi.controlOfDirectors, (control) => {
   }
   if (!control.actingJointly) {
     inputFormSi.directorsActingJointly = []
+  }
+})
+
+watch(isControlSelected, (newValue) => {
+  inputFormSi.isControlSelected = newValue
+
+  if (!newValue && !inputFormSi.couldNotProvideMissingInfo) {
+    addIndividualForm.value?.setErrors([{
+      message: t('errors.validation.control') + 'BBB',
+      path: 'isControlSelected'
+    }], 'isControlSelected')
+  } else {
+    addIndividualForm.value?.clear('isControlSelected')
   }
 })
 </script>

--- a/btr-web/btr-main-app/components/individual-person/control/PercentageSelector.vue
+++ b/btr-web/btr-main-app/components/individual-person/control/PercentageSelector.vue
@@ -51,6 +51,7 @@ const selectOption = (index: number) => {
   if (selected.value === index) {
     selected.value = -1
     model.value = 'noSelection'
+    emit('change')
     return
   }
   selected.value = index

--- a/btr-web/btr-main-app/cypress/e2e/pages/formValidation.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/pages/formValidation.cy.ts
@@ -141,4 +141,76 @@ describe('pages -> Form Validation', () => {
     cy.get('[data-cy="controlOfVotes.registeredOwner"]').check()
     cy.contains(i18n.errors.validation.sharesAndVotes.required).should('not.exist')
   })
+
+  it(`when the 'Unable to Obtain or Confirm Information' checkbox is checked, only name, declaration, and reason 
+    for missing information is required`, () => {
+    cy.get('[data-cy=add-new-btn]').click()
+    cy.get('input[data-cy="testFullName"]').focus().type('my name')
+    cy.get('[data-cy="declaration-button-none"]').click()
+    cy.get('[data-cy="isUnableToObtainOrConfirmInformationCheckbox"]').check()
+    cy.get('[data-cy="isUnableToObtainOrConfirmInformationTextArea"] >> textarea')
+      .type('Missing information reason')
+
+    cy.get('[data-cy=new-si-done-btn]').click()
+    cy.get('[data-cy="addIndividualPerson"]').should('not.exist')
+  })
+
+  it(`when editing an existing SI with full information, we should be able to delete required fields when 
+    Unable to Obtain or Confirm Information is checked`, () => {
+    cy.get('[data-cy=action-button]').eq(3).click()
+    cy.get('[data-cy="isUnableToObtainOrConfirmInformationCheckbox"]').check()
+    cy.get('[data-cy="isUnableToObtainOrConfirmInformationTextArea"] >> textarea')
+      .type('Missing information reason')
+
+    // delete email
+    cy.get('[data-cy="testEmail"] input').type('AA').blur()
+    cy.contains(i18nCommon.errors.validation.email.invalid).should('exist')
+    cy.get('[data-cy="testEmail"] input').type('{backspace}{backspace}').blur()
+
+    // delete street address
+    cy.get('[data-cy="address-street"]').type('AA').blur().type('{backspace}{backspace}').blur()
+
+    // select other citizenship without selecting any country
+    cy.get('[data-cy="citizenships-other-radio"]').click()
+
+    // should be able to save changes by clicking the Done button
+    cy.get('[data-cy=new-si-done-btn]').click()
+    cy.get('[data-cy="addIndividualPerson"]').should('not.exist')
+  })
+
+  it(`When editing an existing SI with missing information, we should be able to add more information.
+   trigger all errors: email, physical address, control type.`, () => {
+    cy.get('[data-cy=action-button]').eq(0).click()
+    const email = 'new_email@email.com'
+    const streetAddress = '123 Main St'
+    const city = 'town'
+    const postalCode = 'abc123'
+    const birthdate = '1990-01-01'
+
+    // add email
+    // when email is invalid, it should show an error
+    cy.get('[data-cy="testEmail"] input').type('AA').blur()
+    cy.contains(i18nCommon.errors.validation.email.invalid).should('exist')
+    cy.get('[data-cy="testEmail"] input').type(email).blur()
+
+    // add physical address
+    cy.get('[data-cy="address-street"]').type(streetAddress).blur()
+    cy.get('[data-cy="address-city"]').type(city).blur()
+    cy.get('[data-cy="address-postal-code"]').type(postalCode).blur()
+
+    // add birthdate
+    cy.get('input[name="birthDate"][data-cy="date-select"]').type(birthdate).blur()
+
+    // click done button
+    cy.get('[data-cy=new-si-done-btn]').click()
+    cy.get('[data-cy="addIndividualPerson"]').should('not.exist')
+
+    // verify the added information is displayed in the summary table
+    const updatedSI = cy.get('[data-cy="summary-table-row"]').first()
+    updatedSI.get('[data-cy=summary-table-details]').contains(email)
+    updatedSI.get('[data-cy=summary-table-details]').contains(streetAddress)
+    updatedSI.get('[data-cy=summary-table-details]').contains(city)
+    updatedSI.get('[data-cy=summary-table-details]').contains(postalCode)
+    updatedSI.get('[data-cy=summary-table-name]').contains(birthdate)
+  })
 })

--- a/btr-web/btr-main-app/cypress/e2e/pages/formValidation.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/pages/formValidation.cy.ts
@@ -180,7 +180,7 @@ describe('pages -> Form Validation', () => {
 
   it(`When editing an existing SI with missing information, we should be able to add more information.
    trigger all errors: email, physical address, control type.`, () => {
-    cy.get('[data-cy=action-button]').eq(0).click()
+    cy.get('[data-cy=action-button]').eq(3).click()
     const email = 'new_email@email.com'
     const streetAddress = '123 Main St'
     const city = 'town'

--- a/btr-web/btr-main-app/cypress/e2e/pages/tables/controlTable.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/pages/tables/controlTable.cy.ts
@@ -11,6 +11,8 @@ describe('pages -> Control Table', () => {
     cy.get('[data-cy=action-button]').eq(0).click()
     cy.get('[data-cy="controlOfShares.jointlyOrInConcert.hasJointlyOrInConcert"]').uncheck()
     cy.get('[data-cy=new-si-done-btn]').click()
+    // wait 1 second for updating row
+    cy.wait(1000)
     cy.get('[data-cy=action-button]').eq(2).click()
     cy.get('[data-cy="controlOfShares.jointlyOrInConcert.hasJointlyOrInConcert"]').uncheck()
     cy.get('[data-cy=new-si-done-btn]').click()
@@ -103,7 +105,7 @@ describe('pages -> Control Table', () => {
     })
   })
 
-  it('A warning message is displayed when only one siginiciant individual has shared control', () => {
+  it('A warning message is displayed when only one significant individual has shared control', () => {
     // remove the shared control in the first SI
     cy.get('[data-cy=action-button]').eq(0).click()
     cy.get('[data-cy="controlOfShares.jointlyOrInConcert.hasJointlyOrInConcert"]').uncheck()

--- a/btr-web/btr-main-app/cypress/e2e/pages/tables/summaryTable.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/pages/tables/summaryTable.cy.ts
@@ -40,28 +40,36 @@ describe('pages -> Summary Table', () => {
         for (const country of personStmnt?.nationalities || []) {
           cy.get('@nameItem').find(`.f-${country.code.toLowerCase()}`).should('exist')
         }
+
+        cy.get('@summaryRow').find('[data-cy=summary-table-details]').as('detailsItem')
+
         // address
-        const address = personStmnt?.addresses[0]
-        cy.get('@summaryRow')
-          .find('[data-cy=summary-table-details]').as('detailsItem')
-          .should('contain.text', address?.street)
-          .should('contain.text', address?.city)
-          .should('contain.text', address?.region)
-          .should('contain.text', address?.countryName)
-          .should('contain.text', address?.postalCode)
-          .should('contain.text', address?.locationDescription)
+        if (personStmnt?.addresses?.length) {
+          const address = personStmnt?.addresses[0]
+          cy.get('@detailsItem')
+            .should('contain.text', address?.street)
+            .should('contain.text', address?.city)
+            .should('contain.text', address?.region)
+            .should('contain.text', address?.countryName)
+            .should('contain.text', address?.postalCode)
+            .should('contain.text', address?.locationDescription)
+        }
         // tax number
         if (personStmnt?.hasTaxNumber) {
           cy.get('@detailsItem').should('contain.text', personStmnt?.identifiers[0].id)
         }
         // tax residency
-        if (personStmnt?.taxResidencies.length) {
+        if (personStmnt?.taxResidencies?.length) {
           cy.get('@detailsItem').should('contain.text', personStmnt?.taxResidencies[0].name)
         }
         // email
-        cy.get('@detailsItem').should('contain.text', personStmnt?.email)
+        if (personStmnt?.email) {
+          cy.get('@detailsItem').should('contain.text', personStmnt?.email)
+        }
         // phone
-        cy.get('@detailsItem').should('contain.text', personStmnt?.phoneNumber.number)
+        if (personStmnt?.phoneNumber?.number) {
+          cy.get('@detailsItem').should('contain.text', personStmnt?.phoneNumber?.number)
+        }
         // interests / dates
         cy.get('@summaryRow')
           .find('[data-cy=summary-table-controls]').as('controlItem')
@@ -69,6 +77,7 @@ describe('pages -> Summary Table', () => {
         cy.get('@summaryRow')
           .find('[data-cy=summary-table-dates]').as('datesItem')
           .should('exist')
+
         for (const interest of ownrStmnt.interests) {
           // control
           switch (interest.details) {
@@ -252,18 +261,18 @@ describe('pages -> Summary Table', () => {
     cy.get('[data-cy="individualsSummaryTable"]').as('summaryTable')
       .find('[data-cy="summary-table-row"]').as('summaryRow')
       .should('exist')
-      .should('have.length', 3)
+      .should('have.length', 4)
 
     cy.addTestIndividuals(false)
     // should trigger 'updating' on all rows for 1 second
     cy.get('@summaryTable').find('[data-cy="summary-table-row-updating"]')
       .should('exist')
-      .should('have.length', 4)
+      .should('have.length', 5)
       .as('rowsUpdating')
     cy.wait(1000)
     cy.get('@rowsUpdating').should('not.exist')
 
-    cy.get('@summaryRow').should('have.length', 4)
+    cy.get('@summaryRow').should('have.length', 5)
 
     cy.fixture('individuals').then((testData) => {
       cy.get('@summaryRow').first().find('[data-cy=summary-table-name]').as('nameItem')
@@ -307,12 +316,12 @@ describe('pages -> Summary Table', () => {
       // should trigger 'updating' row for 1 second
       cy.get('@summaryTable').find('[data-cy="summary-table-row-updating"]')
         .should('exist')
-        .should('have.length', 3)
+        .should('have.length', 4)
         .as('rowsUpdating')
       cy.wait(1000)
       cy.get('@rowsUpdating').should('not.exist')
       // verify removal
-      cy.get('@summaryRow').should('have.length', 3)
+      cy.get('@summaryRow').should('have.length', 4)
       cy.get('@nameItem').should('not.contain.text', testData.profile1.fullName)
       cy.get('@nameItem').find('[data-cy="name-badge"]').should('not.exist')
       cy.get('@actionButton').should('contain.text', 'Update')

--- a/btr-web/btr-main-app/cypress/fixtures/plotsEntityExistingSiResponse.json
+++ b/btr-web/btr-main-app/cypress/fixtures/plotsEntityExistingSiResponse.json
@@ -387,9 +387,91 @@
                 "subject": {
                     "describedByEntityStatement": ""
                 }
+            },
+            {
+                "interestTypes": [
+                    "shareholding"
+                ],
+                "interestedParty": {
+                    "describedByPersonStatement": "d54fe479-8f35-4436-b57c-51de5df17681"
+                },
+                "interests": [
+                    {
+                    "details": "controlType.shares.registeredOwner",
+                    "directOrIndirect": "direct",
+                    "share": {
+                        "exclusiveMaximum": true,
+                        "exclusiveMinimum": false,
+                        "maximum": 25,
+                        "minimum": 0
+                    },
+                    "type": "shareholding"
+                    }
+                ],
+                "isComponent": false,
+                "publicationDetails": {
+                    "bodsVersion": "0.3",
+                    "publicationDate": "2025-05-28",
+                    "publisher": {
+                    "name": "BCROS - BC Registries and Online Services",
+                    "url": "https://www.bcregistry.gov.bc.ca/"
+                    }
+                },
+                "source": {
+                    "assertedBy": [
+                    {
+                        "name": "BCREG2 Liang FORTY"
+                    }
+                    ],
+                    "description": "Using Gov BC - BTR - Web UI",
+                    "type": [
+                    "selfDeclaration"
+                    ]
+                },
+                "statementDate": "2025-05-28",
+                "statementID": "06c5a091-6703-4909-878c-38c623eab110",
+                "statementType": "ownershipOrControlStatement",
+                "subject": {
+                    "describedByEntityStatement": ""
+                }
             }
         ],
         "personStatements": [
+            {
+                "isComponent": false,
+                "missingInfoReason": "some information is missing",
+                "names": [
+                    {
+                        "fullName": "Jane Doe",
+                        "type": "individual"
+                    }
+                ],
+                "personType": "knownPerson",
+                "publicationDetails": {
+                    "bodsVersion": "0.3",
+                    "publicationDate": "2025-05-28",
+                    "publisher": {
+                    "name": "BCROS - BC Registries and Online Services",
+                    "url": "https://www.bcregistry.gov.bc.ca/"
+                    }
+                },
+                "source": {
+                    "assertedBy": [
+                    {
+                        "name": "BCREG2 Liang FORTY"
+                    }
+                    ],
+                    "description": "Using Gov BC - BTR - Web UI",
+                    "type": [
+                        "selfDeclaration"
+                    ]
+                },
+                "statementDate": "2025-05-28",
+                "statementID": "d54fe479-8f35-4436-b57c-51de5df17681",
+                "statementType": "personStatement",
+                "uuid": "47367362-2082-44fd-8ec2-558c03726a03",
+                "verificationStatus": "unverified"
+            },
             {
                 "verificationStatus": "verified_by_self",
                 "addresses": [

--- a/btr-web/btr-main-app/cypress/fixtures/plotsEntityExistingSiResponse.json
+++ b/btr-web/btr-main-app/cypress/fixtures/plotsEntityExistingSiResponse.json
@@ -41,6 +41,7 @@
                 "interestedParty": {
                     "describedByPersonStatement": "1ce633f7-0d61-4075-bb3a-f66a797e1a14"
                 },
+                "interestTypes": ["shareholding"],
                 "interests": [
                     {
                         "details": "controlType.shares.beneficialOwner",
@@ -87,6 +88,7 @@
                 "interestedParty": {
                     "describedByPersonStatement": "752ec662-ed65-4308-b456-f7df744e09bd"
                 },
+                "interestTypes": ["shareholding"],
                 "interests": [
                     {
                         "details": "controlType.shares.registeredOwner",
@@ -151,6 +153,7 @@
                 "interestedParty": {
                     "describedByPersonStatement": "161f5c5e-b9ac-4fbc-a7fc-349d85e5b546"
                 },
+                "interestTypes": ["shareholding", "votingRights", "appointmentOfBoard"],
                 "interests": [
                     {
                         "details": "controlType.directors.indirectControl",
@@ -238,6 +241,7 @@
                 "interestedParty": {
                     "describedByPersonStatement": "fakestatementid-4959391-fjjlekf"
                 },
+                "interestTypes": ["shareholding"],
                 "interests": [
                     {
                         "details": "controlType.shares.registeredOwner",
@@ -302,6 +306,7 @@
                 "interestedParty": {
                     "describedByPersonStatement": "979a1dbc-9131-4b45-8dad-82a7ccf517f1"
                 },
+                "interestTypes": ["shareholding", "votingRights"],
                 "interests": [
                     {
                         "details": "controlType.shares.registeredOwner",
@@ -330,12 +335,6 @@
                         "type": "votingRights"
                     },
                     {
-                        "details": "something",
-                        "endDate": "2021-08-04",
-                        "startDate": "2017-08-03",
-                        "type": "otherInfluenceOrControl"
-                    },
-                    {
                         "details": "controlType.shares.registeredOwner",
                         "directOrIndirect": "direct",
                         "endDate": "2024-08-02",
@@ -360,12 +359,6 @@
                         },
                         "startDate": "2024-08-01",
                         "type": "votingRights"
-                    },
-                    {
-                        "details": "something",
-                        "endDate": "2024-08-02",
-                        "startDate": "2024-08-01",
-                        "type": "otherInfluenceOrControl"
                     }
                 ],
                 "isComponent": false,

--- a/btr-web/btr-main-app/cypress/fixtures/plotsEntityExistingSiResponse.json
+++ b/btr-web/btr-main-app/cypress/fixtures/plotsEntityExistingSiResponse.json
@@ -438,41 +438,6 @@
         ],
         "personStatements": [
             {
-                "isComponent": false,
-                "missingInfoReason": "some information is missing",
-                "names": [
-                    {
-                        "fullName": "Jane Doe",
-                        "type": "individual"
-                    }
-                ],
-                "personType": "knownPerson",
-                "publicationDetails": {
-                    "bodsVersion": "0.3",
-                    "publicationDate": "2025-05-28",
-                    "publisher": {
-                    "name": "BCROS - BC Registries and Online Services",
-                    "url": "https://www.bcregistry.gov.bc.ca/"
-                    }
-                },
-                "source": {
-                    "assertedBy": [
-                    {
-                        "name": "BCREG2 Liang FORTY"
-                    }
-                    ],
-                    "description": "Using Gov BC - BTR - Web UI",
-                    "type": [
-                        "selfDeclaration"
-                    ]
-                },
-                "statementDate": "2025-05-28",
-                "statementID": "d54fe479-8f35-4436-b57c-51de5df17681",
-                "statementType": "personStatement",
-                "uuid": "47367362-2082-44fd-8ec2-558c03726a03",
-                "verificationStatus": "unverified"
-            },
-            {
                 "verificationStatus": "verified_by_self",
                 "addresses": [
                     {
@@ -877,6 +842,41 @@
                 "statementType": "personStatement",
                 "taxResidencies": [],
                 "uuid": "fakestatementid-4959391-fjjlekf"
+            },
+            {
+                "isComponent": false,
+                "missingInfoReason": "some information is missing",
+                "names": [
+                    {
+                        "fullName": "Jane Doe",
+                        "type": "individual"
+                    }
+                ],
+                "personType": "knownPerson",
+                "publicationDetails": {
+                    "bodsVersion": "0.3",
+                    "publicationDate": "2025-05-28",
+                    "publisher": {
+                    "name": "BCROS - BC Registries and Online Services",
+                    "url": "https://www.bcregistry.gov.bc.ca/"
+                    }
+                },
+                "source": {
+                    "assertedBy": [
+                    {
+                        "name": "BCREG2 Liang FORTY"
+                    }
+                    ],
+                    "description": "Using Gov BC - BTR - Web UI",
+                    "type": [
+                        "selfDeclaration"
+                    ]
+                },
+                "statementDate": "2025-05-28",
+                "statementID": "d54fe479-8f35-4436-b57c-51de5df17681",
+                "statementType": "personStatement",
+                "uuid": "47367362-2082-44fd-8ec2-558c03726a03",
+                "verificationStatus": "unverified"
             }
         ]
     },

--- a/btr-web/btr-main-app/utils/si-schema/definitions.ts
+++ b/btr-web/btr-main-app/utils/si-schema/definitions.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod'
+import { PhoneSchema } from '../../../btr-common-components/interfaces/zod-schemas-t'
 import { PercentageRangeE } from '~/enums/percentage-range-e'
 import { DeclarationTypeE } from '@/enums/declaration-type-e'
 
-const StartEndDateGroup = z.object({
+export const StartEndDateGroup = z.object({
   startDate: z.string().min(1),
   endDate: z.string().optional()
 })
@@ -65,13 +66,14 @@ export type CitizenshipSchemaType = z.infer<typeof CitizenshipSchema>
 
 export const AddressSchema = z.object({
   country: CountrySchema.optional(),
-  line1: z.string().min(1),
+  line1: z.string().optional(),
   line2: z.string().optional(),
-  city: z.string().min(1),
-  region: z.string().min(1),
-  postalCode: z.string().min(1),
+  city: z.string().optional(),
+  region: z.string().optional(),
+  postalCode: z.string().optional(),
   locationDescription: z.string().optional()
 })
+
 export type AddressSchemaType = z.infer<typeof AddressSchema>
 
 export const SiSchema = z.object({
@@ -99,8 +101,7 @@ export const SiSchema = z.object({
   tax: TaxSchema,
   isTaxResident: z.boolean().optional(),
   determinationOfIncapacity: z.boolean(),
-  phoneNumber: getPhoneNumberValidator(),
-
+  phoneNumber: PhoneSchema,
   effectiveDates: z.array(StartEndDateGroup).min(1),
 
   uuid: z.string().min(1),

--- a/btr-web/btr-main-app/utils/validation.ts
+++ b/btr-web/btr-main-app/utils/validation.ts
@@ -1,6 +1,6 @@
 import { type RefinementCtx, z } from 'zod'
 import { PercentageRangeE } from '~/enums/percentage-range-e'
-import type { CitizenshipSchemaType, SiNameSchemaType, SiSchemaType } from '~/utils/si-schema/definitions'
+import type { CitizenshipSchemaType, SiNameSchemaType } from '~/utils/si-schema/definitions'
 
 /**
  * Validate the Type of Director Control checkboxes.
@@ -478,15 +478,15 @@ export function validateEditFormSchemaSuperRefine (schema: any, ctx: RefinementC
         })
       }
     }
-  }
 
-  // citizenship
-  if (schema.ui.newOrUpdatedFields.includes(InputFieldsE.CITIZENSHIPS)) {
-    ctx.path.push('citizenships')
-    validateCitizenshipSuperRefine(schema.citizenships, ctx)
-    const citizenshipPath = ctx.path.findIndex(v => v === 'citizenships')
-    if (citizenshipPath !== -1) {
-      ctx.path.splice(citizenshipPath, 1)
+    // citizenship
+    if (schema.ui.newOrUpdatedFields.includes(InputFieldsE.CITIZENSHIPS)) {
+      ctx.path.push('citizenships')
+      validateCitizenshipSuperRefine(schema.citizenships, ctx)
+      const citizenshipPath = ctx.path.findIndex(v => v === 'citizenships')
+      if (citizenshipPath !== -1) {
+        ctx.path.splice(citizenshipPath, 1)
+      }
     }
   }
 

--- a/btr-web/btr-main-app/utils/validation.ts
+++ b/btr-web/btr-main-app/utils/validation.ts
@@ -296,7 +296,7 @@ export function validatePhoneNumberSuperRefine (phoneNumber: PhoneSchemaType, ct
 }
 
 // Refine the entire SiSchema in the Edit form to apply all validation rules that are not covered by the schema itself.
-export function validateEditFormSchemaSuperRefine (schema: SiSchemaType, ctx: RefinementCtx): never {
+export function validateEditFormSchemaSuperRefine (schema: any, ctx: RefinementCtx): never {
   const t = useNuxtApp().$i18n.t
 
   // Control of Shares


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/28486

*Description of changes:*
The form schema has been refactored to address the following issue:
- If an existing SI has 'unable-to-obtain-information == true', in Edit form, we are not able to input new information for those fields that are previously empty
- When editing an existing SI, users should be able to clear some input and leave it empty, when they select the 'unable-to-obtain-information' checkbox.

See the ticket for more details of the bugs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
