### PR TITLE
Skip validating filing type

### DIFF
--- a/btr-api/.env.sample
+++ b/btr-api/.env.sample
@@ -1,8 +1,8 @@
 # Config setting
 DEPLOYMENT_ENV=development
 
-# temporarily skip validating CHANGE_FILING' and 'ANNUAL_FILING'
-SKIP_CHANGE_AND_ANNUAL_FILING_VALIDATION=True
+# temporarily skip validating filing types
+SKIP_FILING_VALIDATION=True
 
 # third party Services
 #CODECOV_TOKEN=

--- a/btr-api/src/btr_api/config.py
+++ b/btr-api/src/btr_api/config.py
@@ -123,8 +123,8 @@ class Config:  # pylint: disable=too-few-public-methods
 
     DAYS_TO_AUTO_REJECT_REQUESTS = os.getenv('DAYS_TO_AUTO_REJECT_REQUESTS', '60')
 
-    SKIP_CHANGE_AND_ANNUAL_FILING_VALIDATION = \
-        os.getenv('SKIP_CHANGE_AND_ANNUAL_FILING_VALIDATION', 'false').lower() == 'true'
+    SKIP_FILING_VALIDATION = \
+        os.getenv('SKIP_FILING_VALIDATION', 'false').lower() == 'true'
 
     # Cache stuff
     CACHE_TYPE = os.getenv('CACHE_TYPE', 'FileSystemCache')
@@ -199,7 +199,7 @@ class Testing(Config):  # pylint: disable=too-few-public-methods
     BOR_SVC_URL = 'https://test-bor-url'
     NOTIFY_SVC_URL = 'https://test-notify-api-url'
 
-    SKIP_CHANGE_AND_ANNUAL_FILING_VALIDATION = False
+    SKIP_FILING_VALIDATION = False
 
     SSO_SVC_TOKEN_URL = 'https://test-token-url'
     SVC_ACC_CLIENT_ID = 'service-account'

--- a/btr-api/src/btr_api/services/validator.py
+++ b/btr-api/src/btr_api/services/validator.py
@@ -89,8 +89,7 @@ def validate_tr_filing_for_type(submission: dict, jwt: JwtManager) -> list[str]:
     Returns:
     list[str]: A list of errors, if any, found during validation
     """
-    skip_filing_validation = current_app.config.get('SKIP_CHANGE_AND_ANNUAL_FILING_VALIDATION', False)
-    if skip_filing_validation:
+    if current_app.config.get('SKIP_FILING_VALIDATION', False):
         return []
 
     filing_type = submission['filingType']

--- a/btr-api/src/btr_api/services/validator.py
+++ b/btr-api/src/btr_api/services/validator.py
@@ -89,20 +89,23 @@ def validate_tr_filing_for_type(submission: dict, jwt: JwtManager) -> list[str]:
     Returns:
     list[str]: A list of errors, if any, found during validation
     """
+    skip_filing_validation = current_app.config.get('SKIP_CHANGE_AND_ANNUAL_FILING_VALIDATION', False)
+    if skip_filing_validation:
+        return []
+
     filing_type = submission['filingType']
     business_identifier = submission['businessIdentifier']
     entity_service = EntityService(current_app)
     todos = (entity_service.get_entity_info(jwt, f'{business_identifier}/tasks')).json().get('tasks', [])
-    skip_change_and_annual_filing_validation = current_app.config.get('SKIP_CHANGE_AND_ANNUAL_FILING_VALIDATION', False)
 
     if filing_type == 'INITIAL_FILING':
         return _validate_initial_filing(todos)
 
     if filing_type == 'CHANGE_FILING':
-        return [] if skip_change_and_annual_filing_validation else _validate_change_filing(todos)
+        return _validate_change_filing(todos)
 
     if filing_type == 'ANNUAL_FILING':
-        return [] if skip_change_and_annual_filing_validation else _validate_ar_filing(todos, submission)
+        return _validate_ar_filing(todos, submission)
 
     return ['Invalid filingType']
 


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/28920

*Description of changes:*
TR filing has been turned off in legal-api. Validation for all three filing types (initial, change, annual) need to be skipped in BTR-API for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
