### PR TITLE
28518 - fix the country code deselect bug in Phone Number component

### DIFF
--- a/btr-web/btr-common-components/components/bcros/inputs/PhoneNumber/CountryCode.vue
+++ b/btr-web/btr-common-components/components/bcros/inputs/PhoneNumber/CountryCode.vue
@@ -1,5 +1,6 @@
 <template>
   <UInputMenu
+    ref="inputMenu"
     v-model="selectedCountry"
     v-model:query="query"
     :options="countryListOptions"
@@ -42,7 +43,6 @@
       <div
         class="w-full flex items-center gap-1"
         data-cy="countryCodeOption"
-        @click.prevent="onSelect(optionItem)"
       >
         <BcrosCountryFlag
           :tooltip-text="optionItem.countryNameLocal"
@@ -65,6 +65,7 @@ const countryCode2letterIso = defineModel<string | undefined>('countryCode2lette
 
 const selectedCountry = ref<CountryListItemI | undefined>(undefined)
 const query = ref('')
+const inputMenu = ref()
 
 const _countryListOptions =
   countryList.customList('countryCode', '{countryCallingCode},{countryNameEn},{countryNameLocal}')
@@ -108,16 +109,6 @@ const onBlur = () => {
   }
 }
 
-const onSelect = (option: CountryListItemI) => {
-  if (selectedCountry.value !== undefined &&
-    selectedCountry.value.countryCode2letterIso === option.countryCode2letterIso) {
-    selectedCountry.value = undefined
-  } else {
-    selectedCountry.value = option
-    query.value = ''
-  }
-}
-
 const selectCountry = (countryCode2letterIso: string) => {
   selectedCountry.value = countryListOptions.find(item => item.countryCode2letterIso === countryCode2letterIso)
 }
@@ -129,6 +120,20 @@ if (countryCode2letterIso.value !== undefined) {
     countryCallingCode: `+${countryCallingCode.value}`
   }
 }
+
+onMounted(() => {
+  if (inputMenu.value) {
+    inputMenu.value.onUpdate = (option: any) => {
+      if (selectedCountry.value !== undefined &&
+        selectedCountry.value.countryCode2letterIso === option.countryCode2letterIso) {
+        selectedCountry.value = undefined
+      } else {
+        selectedCountry.value = option
+        query.value = ''
+      }
+    }
+  }
+})
 
 watch(
   selectedCountry,

--- a/btr-web/btr-main-app/cypress/e2e/pages/add-individual/phone-number.cy.ts
+++ b/btr-web/btr-main-app/cypress/e2e/pages/add-individual/phone-number.cy.ts
@@ -12,8 +12,7 @@ describe('pages -> Add individual', () => {
     cy.get('[data-cy="phoneNumber.extensionCode"]').should('exist')
   })
 
-  // todo: when resolving #28518 make sure this tests is passing
-  it.skip('verify country code combobox behaviour', () => {
+  it('verify country code combobox behaviour', () => {
     // Case 1: phone country code is prepopulated when selecting country address
     cy.get('[data-cy="address-country"]')
       .click()
@@ -49,6 +48,8 @@ describe('pages -> Add individual', () => {
       .get('[data-cy="phoneNumberInput"]')
       .find('input+span .flag.f-ca')
       .should('exist')
+      .get('[data-cy="expandCountryCodeDropdown"]')
+      .click()
       .get('[data-cy="countryCodeOption"]').eq(3) // select the US
       .click()
       .get('[data-cy="phoneNumberInput"]')
@@ -56,7 +57,9 @@ describe('pages -> Add individual', () => {
       .should('exist')
 
     // Case 4: unselect a country by clicking on the option again
-    cy.get('[data-cy="countryCodeOption"]').eq(3)
+    cy.get('[data-cy="expandCountryCodeDropdown"]')
+      .click()
+      .get('[data-cy="countryCodeOption"]').eq(3)
       .click()
       .get('[data-cy="phoneNumber.countryCode"]')
       .should('have.value', '')
@@ -65,7 +68,9 @@ describe('pages -> Add individual', () => {
       .should('not.exist')
 
     // Case 5: delete the country by clicking the delete button
-    cy.get('[data-cy="countryCodeOption"]').eq(0) // select Canada
+    cy.get('[data-cy="expandCountryCodeDropdown"]')
+      .click()
+      .get('[data-cy="countryCodeOption"]').eq(0) // select Canada
       .click()
       .get('[data-cy="clearCountryCode"]') // click the 'X' button
       .click()


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/28518

*Description of changes:*
- Fix the bug so users can deselect a country code by clicking it in the dropdown menu
- Before this bug occurred, users can deselect a country by clicking it in the dropdown. But after unselecting a country, the dropdown does not collapse. UI/UX were complaining about this. It gets fixed in this PR. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
