### PR TITLE
chore: upgrade to Node.js 24

### DIFF
--- a/.github/workflows/btr-ui-main-cd.yml
+++ b/.github/workflows/btr-ui-main-cd.yml
@@ -25,7 +25,7 @@ jobs:
     uses: bcgov/bcregistry-sre/.github/workflows/frontend-cd.yaml@main
     with:
       target: ${{ inputs.environment }}
-      node_version: 20
+      node_version: "24"
       working_directory: "./btr-web"
       app_name: "btr-ui"
     secrets:

--- a/btr-web/package.json
+++ b/btr-web/package.json
@@ -2,6 +2,9 @@
   "name": "btr-web",
   "version": "0.1.0",
   "description": "Beneficial Ownership Registry UI - Mono repo workspace",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "pnpm --filter-prod btr-main-app build",
     "build:btr-main-app": "pnpm --filter-prod btr-main-app build",


### PR DESCRIPTION
*Issue #:* https://app.zenhub.com/workspaces/sre-team-board-654d163c6817d80016102d9a/issues/gh/bcgov/entity/32835

*Description of changes:*
Update engines field in package.json to require Node.js >= 24.
Update GitHub Actions CI/CD workflows to use Node 24.
Align with modern runtime standards and ensure pipeline stability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the bcrs-entities-create-ui license (Apache 2.0).
