### PR TITLE
[TEST] pnpm v11 upgrade - CI validation

### DIFF
--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -22,7 +22,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: btr-web/btr-main-app/pnpm-lock.yaml
       - name: Install
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
       - name: Build
         run: pnpm build
       - name: Verify pnpm version

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -1,0 +1,29 @@
+name: "[TEST] pnpm v11 upgrade"
+on:
+  push:
+    branches: ["test/pnpm-v11-upgrade"]
+  workflow_dispatch:
+
+jobs:
+  test-pnpm-v11:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: btr-web/btr-main-app
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup pnpm v11
+        uses: pnpm/action-setup@v6
+        with:
+          version: latest-11
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: btr-web/btr-main-app/pnpm-lock.yaml
+      - name: Install
+        run: pnpm install
+      - name: Build
+        run: pnpm build
+      - name: Verify pnpm version
+        run: pnpm --version

--- a/.github/workflows/test-pnpm-v11.yml
+++ b/.github/workflows/test-pnpm-v11.yml
@@ -22,7 +22,7 @@ jobs:
           cache: pnpm
           cache-dependency-path: btr-web/btr-main-app/pnpm-lock.yaml
       - name: Install
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --no-frozen-lockfile --ignore-scripts
       - name: Build
         run: pnpm build
       - name: Verify pnpm version


### PR DESCRIPTION
## Test PR — do not merge

This PR exists solely to trigger CI and validate that pnpm v11 is compatible.

- Runs `test-pnpm-v11.yml` (or `test-pnpm-v11-ci.yml`) which uses `pnpm@latest-11`
- Does **not** modify any existing CI workflows
- Will be closed once CI passes and the real upgrade PRs are merged

> Ticket: #33875